### PR TITLE
make module optionally accept host interfaces as generic parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,11 @@ import (
 )
 
 var (
-	endian = flag.String("endian", "", "endianness of the generated code (little or big)")
-	nanbox = flag.Bool("nanbox", false, "whether to try to canonicalize NaNs")
-	nohost = flag.Bool("nohost", false, "disable generating interfaces for imports")
-	nohead = flag.Bool("nohead", false, "disable the header comment (including build tags)")
+	endian  = flag.String("endian", "", "endianness of the generated code (little or big)")
+	nanbox  = flag.Bool("nanbox", false, "whether to try to canonicalize NaNs")
+	nohost  = flag.Bool("nohost", false, "disable generating interfaces for imports")
+	nohead  = flag.Bool("nohead", false, "disable the header comment (including build tags)")
+	generic = flag.Bool("generic", false, "add generic type parameters for host module imports")
 )
 
 // https://pkg.go.dev/golang.org/x/sys/cpu#pkg-constants

--- a/module.go
+++ b/module.go
@@ -62,18 +62,34 @@ func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.Gen
 				Type:  ast.NewIdent(exported(imp.module))})
 		}
 	}
-	for _, g := range t.globals {
-		fields = append(fields, &ast.Field{
-			Names: []*ast.Ident{g.id},
-			Type:  g.typ.Ident()})
-	}
 	var typeParams *ast.FieldList
 	if len(hostInterfaces) > 0 {
+		seen := set[string]{}
 		typeParams = new(ast.FieldList)
 		for _, decl := range hostInterfaces {
 			typeSpec := decl.Specs[0].(*ast.TypeSpec)
+
+			var paramName string
+
+			// Use shortest possible prefix
+			// of the type parameter for
+			// the generic parameter name.
+			typeName := typeSpec.Name.Name
+			for i := 1; i < len(typeName); i++ {
+				if seen.has(typeName[:i]) {
+					continue
+				}
+				paramName = typeName[:i]
+				seen.add(paramName)
+				break
+			}
+
+			if paramName == "" {
+				panic("could not determine type param prefix for: " + typeName)
+			}
+
 			typeParams.List = append(typeParams.List, &ast.Field{
-				Names: []*ast.Ident{typeSpec.Name},
+				Names: []*ast.Ident{ast.NewIdent(paramName)},
 				Type:  newID(typeSpec.Name.Name),
 			})
 		}
@@ -89,28 +105,6 @@ func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.Gen
 		Tok:   token.TYPE,
 		Specs: []ast.Spec{typeSpec},
 	}, typeSpec
-}
-
-func (t *translator) createHostInterfaces() []*ast.GenDecl {
-	ifaces := map[string][]*ast.Field{}
-
-	for _, imp := range t.imports {
-		typ := imp.typ.toAST()
-
-		ifaces[imp.module] = append(ifaces[imp.module], &ast.Field{
-			Names: []*ast.Ident{ast.NewIdent(exported(imp.name))},
-			Type:  typ})
-	}
-
-	decls := make([]*ast.GenDecl, 0, len(ifaces))
-	for name, methods := range ifaces {
-		decls = append(decls, &ast.GenDecl{
-			Tok: token.TYPE,
-			Specs: []ast.Spec{&ast.TypeSpec{
-				Name: ast.NewIdent(exported(name)),
-				Type: &ast.InterfaceType{Methods: &ast.FieldList{List: methods}}}}})
-	}
-	return decls
 }
 
 func (t *translator) createNewFunc() ast.Decl {
@@ -322,17 +316,16 @@ func (t *translator) createNewFunc() ast.Decl {
 	body.List = append(body.List, &ast.ReturnStmt{Results: []ast.Expr{newID("m")}})
 
 	return &ast.FuncDecl{
-		Name: newID("New"),
-		Type: &ast.FuncType{
-			TypeParams: t.moduleType.TypeParams,
+		Name: newID("New"), Type: &ast.FuncType{
 			Params:     &ast.FieldList{List: params},
-			Results:    &ast.FieldList{List: []*ast.Field{{Type: &ast.StarExpr{X: newID("Module")}}}},
+			TypeParams: t.modType.TypeParams,
+			Results:    &ast.FieldList{List: []*ast.Field{{Type: t.modRecv.Type}}},
 		},
 		Body: body,
 	}
 }
 
-func (t *translator) createHostInterfaces() []ast.Decl {
+func (t *translator) createHostInterfaces() []*ast.GenDecl {
 	ifaces := map[string][]*ast.Field{}
 
 	for _, imp := range t.imports {
@@ -353,7 +346,7 @@ func (t *translator) createHostInterfaces() []ast.Decl {
 			Type:  typ})
 	}
 
-	decls := make([]ast.Decl, 0, len(ifaces))
+	decls := make([]*ast.GenDecl, 0, len(ifaces))
 	for name, methods := range ifaces {
 		decls = append(decls, &ast.GenDecl{
 			Tok: token.TYPE,
@@ -362,6 +355,7 @@ func (t *translator) createHostInterfaces() []ast.Decl {
 				Name:   ast.NewIdent(exported(name)),
 				Type:   &ast.InterfaceType{Methods: &ast.FieldList{List: methods}}}}})
 	}
+
 	return decls
 }
 
@@ -470,7 +464,7 @@ func (t *translator) createExportMethods() []ast.Decl {
 		}
 
 		decls = append(decls, &ast.FuncDecl{
-			Recv: modRecvList,
+			Recv: &ast.FieldList{List: []*ast.Field{t.modRecv}},
 			Name: methodName,
 			Type: &ast.FuncType{Results: results},
 			Body: &ast.BlockStmt{List: body}})

--- a/module.go
+++ b/module.go
@@ -7,11 +7,7 @@ import (
 	"strconv"
 )
 
-var modRecvList = &ast.FieldList{List: []*ast.Field{{
-	Names: []*ast.Ident{newID("m")},
-	Type:  &ast.StarExpr{X: newID("Module")}}}}
-
-func (t *translator) createModuleStruct() ast.Decl {
+func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.GenDecl, *ast.TypeSpec) {
 	var fields []*ast.Field
 	// Tables: owned are []any; imported *[]any.
 	for _, tab := range t.tables {
@@ -66,13 +62,55 @@ func (t *translator) createModuleStruct() ast.Decl {
 				Type:  ast.NewIdent(exported(imp.module))})
 		}
 	}
-	return &ast.GenDecl{
-		Tok: token.TYPE,
-		Specs: []ast.Spec{
-			&ast.TypeSpec{
-				Name: newID("Module"),
-				Type: &ast.StructType{Fields: &ast.FieldList{List: fields}}}},
+	for _, g := range t.globals {
+		fields = append(fields, &ast.Field{
+			Names: []*ast.Ident{g.id},
+			Type:  g.typ.Ident()})
 	}
+	var typeParams *ast.FieldList
+	if len(hostInterfaces) > 0 {
+		typeParams = new(ast.FieldList)
+		for _, decl := range hostInterfaces {
+			typeSpec := decl.Specs[0].(*ast.TypeSpec)
+			typeParams.List = append(typeParams.List, &ast.Field{
+				Names: []*ast.Ident{typeSpec.Name},
+				Type:  newID(typeSpec.Name.Name),
+			})
+		}
+	}
+	typeSpec := &ast.TypeSpec{
+		Name:       newID("Module"),
+		TypeParams: typeParams,
+		Type: &ast.StructType{
+			Fields: &ast.FieldList{List: fields},
+		},
+	}
+	return &ast.GenDecl{
+		Tok:   token.TYPE,
+		Specs: []ast.Spec{typeSpec},
+	}, typeSpec
+}
+
+func (t *translator) createHostInterfaces() []*ast.GenDecl {
+	ifaces := map[string][]*ast.Field{}
+
+	for _, imp := range t.imports {
+		typ := imp.typ.toAST()
+
+		ifaces[imp.module] = append(ifaces[imp.module], &ast.Field{
+			Names: []*ast.Ident{ast.NewIdent(exported(imp.name))},
+			Type:  typ})
+	}
+
+	decls := make([]*ast.GenDecl, 0, len(ifaces))
+	for name, methods := range ifaces {
+		decls = append(decls, &ast.GenDecl{
+			Tok: token.TYPE,
+			Specs: []ast.Spec{&ast.TypeSpec{
+				Name: ast.NewIdent(exported(name)),
+				Type: &ast.InterfaceType{Methods: &ast.FieldList{List: methods}}}}})
+	}
+	return decls
 }
 
 func (t *translator) createNewFunc() ast.Decl {
@@ -286,9 +324,12 @@ func (t *translator) createNewFunc() ast.Decl {
 	return &ast.FuncDecl{
 		Name: newID("New"),
 		Type: &ast.FuncType{
-			Params:  &ast.FieldList{List: params},
-			Results: &ast.FieldList{List: []*ast.Field{{Type: &ast.StarExpr{X: newID("Module")}}}}},
-		Body: body}
+			TypeParams: t.moduleType.TypeParams,
+			Params:     &ast.FieldList{List: params},
+			Results:    &ast.FieldList{List: []*ast.Field{{Type: &ast.StarExpr{X: newID("Module")}}}},
+		},
+		Body: body,
+	}
 }
 
 func (t *translator) createHostInterfaces() []ast.Decl {

--- a/module.go
+++ b/module.go
@@ -62,13 +62,16 @@ func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.Gen
 				Type:  ast.NewIdent(exported(imp.module))})
 		}
 	}
+
+	// If host module imports are provided,
+	// use these to generate generic type
+	// parameters for the module struct.
 	var typeParams *ast.FieldList
 	if len(hostInterfaces) > 0 {
 		seen := set[string]{}
 		typeParams = new(ast.FieldList)
 		for _, decl := range hostInterfaces {
 			typeSpec := decl.Specs[0].(*ast.TypeSpec)
-
 			var paramName string
 
 			// Use shortest possible prefix
@@ -88,19 +91,20 @@ func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.Gen
 				panic("could not determine type param prefix for: " + typeName)
 			}
 
+			// Append type parameter with shorted name to list.
 			typeParams.List = append(typeParams.List, &ast.Field{
 				Names: []*ast.Ident{ast.NewIdent(paramName)},
 				Type:  newID(typeSpec.Name.Name),
 			})
 		}
 	}
+
 	typeSpec := &ast.TypeSpec{
 		Name:       newID("Module"),
+		Type:       &ast.StructType{Fields: &ast.FieldList{List: fields}},
 		TypeParams: typeParams,
-		Type: &ast.StructType{
-			Fields: &ast.FieldList{List: fields},
-		},
 	}
+
 	return &ast.GenDecl{
 		Tok:   token.TYPE,
 		Specs: []ast.Spec{typeSpec},

--- a/module.go
+++ b/module.go
@@ -120,7 +120,7 @@ func (t *translator) createNewFunc() ast.Decl {
 				Lhs: []ast.Expr{newID("m")},
 				Rhs: []ast.Expr{&ast.UnaryExpr{
 					Op: token.AND,
-					X:  &ast.CompositeLit{Type: newID("Module")}}}}},
+					X:  &ast.CompositeLit{Type: t.modRecv.Type.(*ast.StarExpr).X}}}}},
 	}
 
 	// Create the params, and initialize fields.

--- a/module.go
+++ b/module.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"slices"
 	"strconv"
+	"strings"
 )
 
 func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.GenDecl, *ast.TypeSpec) {
@@ -78,6 +79,7 @@ func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.Gen
 			// of the type parameter for
 			// the generic parameter name.
 			typeName := typeSpec.Name.Name
+			typeName = strings.TrimPrefix(typeName, "X")
 			for i := 1; i < len(typeName); i++ {
 				if seen.has(typeName[:i]) {
 					continue
@@ -93,7 +95,7 @@ func (t *translator) createModuleStruct(hostInterfaces []*ast.GenDecl) (*ast.Gen
 
 			// Append type parameter with shorted name to list.
 			typeParams.List = append(typeParams.List, &ast.Field{
-				Names: []*ast.Ident{ast.NewIdent(paramName)},
+				Names: []*ast.Ident{ast.NewIdent(strings.ToUpper(paramName))},
 				Type:  newID(typeSpec.Name.Name),
 			})
 		}

--- a/translate.go
+++ b/translate.go
@@ -46,7 +46,8 @@ type translator struct {
 	out ast.File
 
 	// WASM module Go type.
-	moduleType *ast.TypeSpec
+	modType *ast.TypeSpec
+	modRecv *ast.Field
 
 	// Dependencies.
 	packages set[string]
@@ -95,16 +96,33 @@ func translate(r io.Reader, w io.Writer) error {
 		}
 	}
 
+	var hostInterfaces []*ast.GenDecl
+
 	if t.memory != nil && (exported || t.memory.imported) {
 		t.out.Decls = append(t.createMemoryTypes(), t.out.Decls...)
 	}
+
 	if !*nohost && len(t.imports) > 0 {
-		t.out.Decls = append(t.createHostInterfaces(), t.out.Decls...)
+		hostInterfaces = t.createHostInterfaces()
+		t.out.Decls = append(toDecl(hostInterfaces...), t.out.Decls...)
 	}
 
 	// Next define module, with host interface generic param(s).
 	modDecl, modType := t.createModuleStruct(hostInterfaces)
-	t.moduleType = modType
+	t.modRecv = &ast.Field{Names: []*ast.Ident{newID("m")}}
+	t.modType = modType
+
+	// Set module receiver type depending
+	// on if generic type params do exist.
+	if len(modType.TypeParams.List) > 0 {
+		var paramNames []ast.Expr
+		for _, field := range modType.TypeParams.List {
+			paramNames = append(paramNames, field.Names[0])
+		}
+		t.modRecv.Type = &ast.StarExpr{X: &ast.IndexListExpr{X: newID("Module"), Indices: paramNames}}
+	} else {
+		t.modRecv.Type = &ast.StarExpr{X: newID("Module")}
+	}
 
 	t.out.Decls = append([]ast.Decl{
 		modDecl,

--- a/translate.go
+++ b/translate.go
@@ -105,6 +105,13 @@ func translate(r io.Reader, w io.Writer) error {
 	if !*nohost && len(t.imports) > 0 {
 		hostInterfaces = t.createHostInterfaces()
 		t.out.Decls = append(toDecl(hostInterfaces...), t.out.Decls...)
+
+		if !*generic {
+			// Drop host interface slice here, to
+			// prevent generic type parameters being
+			// generated in module creation below.
+			hostInterfaces = nil
+		}
 	}
 
 	// Next define module, with host interface generic param(s).
@@ -114,7 +121,8 @@ func translate(r io.Reader, w io.Writer) error {
 
 	// Set module receiver type depending
 	// on if generic type params do exist.
-	if len(modType.TypeParams.List) > 0 {
+	if modType.TypeParams != nil &&
+		len(modType.TypeParams.List) > 0 {
 		var paramNames []ast.Expr
 		for _, field := range modType.TypeParams.List {
 			paramNames = append(paramNames, field.Names[0])
@@ -138,6 +146,13 @@ func translate(r io.Reader, w io.Writer) error {
 			if fn.decl.Name.Name == "" {
 				// If no function name, generate one.
 				fn.decl.Name.Name = "f" + strconv.Itoa(i)
+			}
+
+			// Skip below
+			// if generics
+			// are disabled.
+			if !*generic {
+				continue
 			}
 
 			// Now module type information is known,

--- a/translate.go
+++ b/translate.go
@@ -44,9 +44,14 @@ var stdlib = map[string]string{
 type translator struct {
 	in  *bufio.Reader
 	out ast.File
+
+	// WASM module Go type.
+	moduleType *ast.TypeSpec
+
 	// Dependencies.
 	packages set[string]
 	helpers  set[string]
+
 	// Sections.
 	types     []funcType
 	imports   []importDef
@@ -89,6 +94,7 @@ func translate(r io.Reader, w io.Writer) error {
 			break
 		}
 	}
+
 	if t.memory != nil && (exported || t.memory.imported) {
 		t.out.Decls = append(t.createMemoryTypes(), t.out.Decls...)
 	}
@@ -96,18 +102,37 @@ func translate(r io.Reader, w io.Writer) error {
 		t.out.Decls = append(t.createHostInterfaces(), t.out.Decls...)
 	}
 
+	// Next define module, with host interface generic param(s).
+	modDecl, modType := t.createModuleStruct(hostInterfaces)
+	t.moduleType = modType
+
 	t.out.Decls = append([]ast.Decl{
-		t.createModuleStruct(),
-		t.createNewFunc()},
-		t.out.Decls...)
+		modDecl,
+		t.createNewFunc(),
+	}, t.out.Decls...)
 
 	// Fill in missing names.
 	if t.out.Name == nil {
 		t.out.Name = newID("wasm2go")
 	}
 	for i, fn := range t.functions {
-		if fn.decl != nil && fn.decl.Name.Name == "" {
-			fn.decl.Name.Name = "f" + strconv.Itoa(i)
+		if fn.decl != nil {
+			if fn.decl.Name.Name == "" {
+				// If no function name, generate one.
+				fn.decl.Name.Name = "f" + strconv.Itoa(i)
+			}
+
+			// Now module type information is known,
+			// update all module receiver methods to
+			// have any determine generic paramter(s).
+			for _, field := range fn.decl.Recv.List {
+				if len(field.Names) > 0 && field.Names[0].Name == "m" {
+					field.Type = &ast.StarExpr{X: &ast.IndexExpr{
+						X:     modType.Name,
+						Index: modType.TypeParams.List[0].Names[0],
+					}}
+				}
+			}
 		}
 	}
 	if t.memory != nil && t.memory.id.Name == "" {
@@ -382,7 +407,16 @@ func (t *translator) readImportSection() error {
 				typ: typ,
 				decl: &ast.FuncDecl{
 					Name: &ast.Ident{},
-					Recv: modRecvList,
+					Recv: &ast.FieldList{
+						List: []*ast.Field{
+							{
+								Names: []*ast.Ident{newID("m")},
+								// Don't set receiving field type
+								// yet, this gets set after module
+								// generic type params are known.
+							},
+						},
+					},
 					Type: typ.toAST(),
 					Body: &ast.BlockStmt{List: []ast.Stmt{stmt}}},
 			}
@@ -487,7 +521,16 @@ func (t *translator) readFunctionSection() error {
 		fn.typ = t.types[index]
 		fn.decl = &ast.FuncDecl{
 			Name: &ast.Ident{},
-			Recv: modRecvList,
+			Recv: &ast.FieldList{
+				List: []*ast.Field{
+					{
+						Names: []*ast.Ident{newID("m")},
+						// Don't set receiving field type
+						// yet, this gets set after module
+						// generic type params are known.
+					},
+				},
+			},
 			Type: fn.typ.toAST(),
 		}
 		t.out.Decls = append(t.out.Decls, fn.decl)

--- a/translate.go
+++ b/translate.go
@@ -148,22 +148,11 @@ func translate(r io.Reader, w io.Writer) error {
 				fn.decl.Name.Name = "f" + strconv.Itoa(i)
 			}
 
-			// Skip below
-			// if generics
-			// are disabled.
-			if !*generic {
-				continue
-			}
-
 			// Now module type information is known,
-			// update all module receiver methods to
-			// have any determine generic paramter(s).
+			// update all module receiver methods with it.
 			for _, field := range fn.decl.Recv.List {
 				if len(field.Names) > 0 && field.Names[0].Name == "m" {
-					field.Type = &ast.StarExpr{X: &ast.IndexExpr{
-						X:     modType.Name,
-						Index: modType.TypeParams.List[0].Names[0],
-					}}
+					field.Type = t.modRecv.Type
 				}
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -2,11 +2,10 @@ package main
 
 import "go/ast"
 
-// appendDecl uses generic parameter typing to allow typical variable argument
-// passing of ast.Decl implementations to append to an []ast.Decl slice.
-func appendDecl[D ast.Decl](decls []ast.Decl, decl ...D) []ast.Decl {
-	for _, decl := range decl {
-		decls = append(decls, decl)
+func toDecl[D ast.Decl](decl ...D) []ast.Decl {
+	decls := make([]ast.Decl, 0, len(decl))
+	for _, d := range decl {
+		decls = append(decls, d)
 	}
 	return decls
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,12 @@
+package main
+
+import "go/ast"
+
+// appendDecl uses generic parameter typing to allow typical variable argument
+// passing of ast.Decl implementations to append to an []ast.Decl slice.
+func appendDecl[D ast.Decl](decls []ast.Decl, decl ...D) []ast.Decl {
+	for _, decl := range decl {
+		decls = append(decls, decl)
+	}
+	return decls
+}


### PR DESCRIPTION
~~mostly just parking this PR here, may pick it up again if there's want for generic host interfaces.~~

~~it generates mostly working code, just the host interface definitions need to be moved to the top of the file, and the module generic parameter definition needs to use a parameter name different to the type of the interface (e.g. X instead of Xenv).~~