### PR TITLE
Embed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,26 @@ Despite the scary name, the generated code abides by the
 [rules of unsafe](https://pkg.go.dev/unsafe#Pointer),
 and all memory accesses are bounds checked.
 
-To generate such Go code:
-```
-wasm2go -unsafe < input.wasm > output.go
-```
-
-The only other knob is whether to attempt to ensure float operations
+Another knob is whether to attempt to ensure float operations
 [canonicalize NaNs](https://github.com/WebAssembly/design/issues/1463).
 This is tested to work on both `amd64` and `arm64`,
 but is known to be broken on most other architectures.
 
+If you suspect `wasm2go` is producing invalid code,
+please try `noopt` too before submitting a bug report.
+
 ```
-Usage of wasm2go:
+Usage: wasm2go [options] [input.wasm]
+  -embed
+        go:embed data sections from a .dat file
   -nanbox
         whether to try to canonicalize NaNs
   -nohost
         disable generating interfaces for imports
   -noopt
         disable all optimization passes
+  -o string
+        output file (default stdout)
   -unsafe
         allow importing unsafe
 ```

--- a/const.go
+++ b/const.go
@@ -109,6 +109,15 @@ func formatInt(i int64) string {
 	return dec
 }
 
+func formatUint(i uint64) string {
+	dec := strconv.FormatUint(i, 10)
+	hex := "0x" + strconv.FormatUint(i, 16)
+	if complexity(hex) < complexity(dec) {
+		return hex
+	}
+	return dec
+}
+
 func formatFloat(f float64, bits int) string {
 	dec := strconv.FormatFloat(f, 'g', -1, bits)
 	hex := strconv.FormatFloat(f, 'x', -1, bits)

--- a/fncompiler.go
+++ b/fncompiler.go
@@ -297,7 +297,7 @@ func (fn *funcCompiler) popAddr(offset uint64) (expr ast.Expr) {
 			X: &ast.BinaryExpr{
 				Op: token.ADD,
 				X:  addr,
-				Y:  &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset, 10)}},
+				Y:  &ast.BasicLit{Kind: token.INT, Value: formatUint(offset)}},
 			Y: &ast.BinaryExpr{
 				Op: token.SHR,
 				X:  addr,
@@ -312,7 +312,7 @@ func (fn *funcCompiler) popAddr(offset uint64) (expr ast.Expr) {
 	return &ast.BinaryExpr{
 		Op: token.ADD,
 		X:  convert(expr, "int64"),
-		Y:  &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset, 10)}}
+		Y:  &ast.BasicLit{Kind: token.INT, Value: formatUint(offset)}}
 }
 
 // Executes a type conversion, first to types[0], then to types[1] and so on.

--- a/main.go
+++ b/main.go
@@ -2,22 +2,70 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 var (
-	embed  = flag.String("embed", "", "go:embed data sections from this file")
+	output = flag.String("o", "", "output file (default stdout)")
+
+	embed  = flag.Bool("embed", false, "go:embed data sections from a .dat file")
 	nanbox = flag.Bool("nanbox", false, "whether to try to canonicalize NaNs")
 	nohost = flag.Bool("nohost", false, "disable generating interfaces for imports")
 	noopt  = flag.Bool("noopt", false, "disable all optimization passes")
 	unsafe = flag.Bool("unsafe", false, "allow importing unsafe")
+
+	embedFile string
 )
 
 func main() {
+	log.SetFlags(0)
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] [input.wasm]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
 	flag.Parse()
-	err := translate(os.Stdin, os.Stdout)
-	if err != nil {
+
+	if flag.NArg() > 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	if *embed {
+		if *output == "" {
+			log.Fatal("-embed requires `-o output.go` to be specified")
+		}
+		embedFile = strings.TrimSuffix(*output, filepath.Ext(*output)) + ".dat"
+	}
+
+	in := os.Stdin
+	if flag.NArg() > 0 {
+		f, err := os.Open(flag.Arg(0))
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		in = f
+	}
+
+	out := os.Stdout
+	if *output != "" {
+		f, err := os.Create(*output)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if err := translate(in, out); err != nil {
+		log.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	embed  = flag.String("embed", "", "go:embed data sections from this file")
 	nanbox = flag.Bool("nanbox", false, "whether to try to canonicalize NaNs")
 	nohost = flag.Bool("nohost", false, "disable generating interfaces for imports")
 	noopt  = flag.Bool("noopt", false, "disable all optimization passes")

--- a/module.go
+++ b/module.go
@@ -231,7 +231,7 @@ func (t *translator) createNewFunc() ast.Decl {
 					&ast.SliceExpr{
 						X:   t.memory.selector,
 						Low: convert(seg.offset, t.memory.utype())},
-					dataID(i)}}})
+					t.dataExpr(i)}}})
 	}
 	// Create and initialize owned globals.
 	for _, g := range t.globals {

--- a/module.go
+++ b/module.go
@@ -221,7 +221,7 @@ func (t *translator) createNewFunc() ast.Decl {
 	}
 	// Intialize the memory.
 	for i, seg := range t.data {
-		if seg.passive {
+		if seg.passive || seg.merged {
 			continue
 		}
 		body.List = append(body.List, &ast.ExprStmt{

--- a/module.go
+++ b/module.go
@@ -136,7 +136,7 @@ func (t *translator) createNewFunc() ast.Decl {
 				X:   newID("m"),
 				Sel: newID("maxMem")}},
 			Rhs: []ast.Expr{
-				&ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(uint64(t.memory.max), 10)}}})
+				&ast.BasicLit{Kind: token.INT, Value: formatInt(t.memory.max)}}})
 		if !t.memory.imported {
 			body.List = append(body.List, &ast.AssignStmt{
 				Tok: token.ASSIGN,
@@ -147,7 +147,7 @@ func (t *translator) createNewFunc() ast.Decl {
 						&ast.ArrayType{Elt: newID("byte")},
 						&ast.BasicLit{
 							Kind:  token.INT,
-							Value: strconv.FormatUint(uint64(t.memory.min)<<16, 10)}}}}})
+							Value: formatInt(t.memory.min << 16)}}}}})
 		}
 	}
 

--- a/testdata/memory/memory.go
+++ b/testdata/memory/memory.go
@@ -17,7 +17,6 @@ func New() *Module {
 	m.maxMem = 100
 	m.memory = make([]byte, 65536)
 	copy(m.memory[uint32(i32(0)):], data0)
-	copy(m.memory[uint32(i32(32)):], data1)
 	return m
 }
 
@@ -84,7 +83,4 @@ func memory_fill[T uint32 | uint64](mem []byte, dest T, val int32, n T) {
 	}
 }
 
-const (
-	data0 = "ghip\xaa\xff\xdf\xcb\x12\xa12\xb3\xa5\x1f\x01\x02"
-	data1 = "\x01\x03\x05\a\t\v\r\x0f"
-)
+const data0 = "ghip\xaa\xff\xdf\xcb\x12\xa12\xb3\xa5\x1f\x01\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x03\x05\a\t\v\r\x0f"

--- a/translate.go
+++ b/translate.go
@@ -12,6 +12,7 @@ import (
 	"go/token"
 	"io"
 	"maps"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -62,6 +63,16 @@ type translator struct {
 	data      []dataSegment
 }
 
+func (t *translator) dataExpr(i int) *ast.ParenExpr {
+	if i >= len(t.data) {
+		t.data = append(t.data, make([]dataSegment, i+1-len(t.data))...)
+	}
+	if t.data[i].embed == nil {
+		t.data[i].embed = &ast.ParenExpr{}
+	}
+	return t.data[i].embed
+}
+
 func translate(r io.Reader, w io.Writer) error {
 	var t translator
 
@@ -80,6 +91,34 @@ func translate(r io.Reader, w io.Writer) error {
 			if err == io.EOF {
 				break
 			}
+			return err
+		}
+	}
+
+	if *embed == "" || len(t.data) == 0 {
+		for i := range t.data {
+			t.dataExpr(i).X = dataID(i)
+		}
+	} else {
+		f, err := os.Create(*embed)
+		if err != nil {
+			return err
+		}
+		var offset int
+		for i, seg := range t.data {
+			n, err := f.Write(seg.init)
+			if err != nil {
+				f.Close()
+				return err
+			}
+			t.dataExpr(i).X = &ast.SliceExpr{
+				X:    newID("data"),
+				Low:  &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(offset)},
+				High: &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(offset + n)},
+			}
+			offset += n
+		}
+		if err := f.Close(); err != nil {
 			return err
 		}
 	}
@@ -151,6 +190,12 @@ func translate(r io.Reader, w io.Writer) error {
 				Path: &ast.BasicLit{Kind: token.STRING, Value: `"` + pkg + `"`},
 			})
 		}
+		if *embed != "" && len(t.data) > 0 {
+			specs = append(specs, &ast.ImportSpec{
+				Name: newID("_"),
+				Path: &ast.BasicLit{Kind: token.STRING, Value: `"embed"`},
+			})
+		}
 		t.out.Decls = append([]ast.Decl{
 			&ast.GenDecl{Tok: token.IMPORT, Specs: specs}},
 			t.out.Decls...)
@@ -158,17 +203,33 @@ func translate(r io.Reader, w io.Writer) error {
 
 	// Add data segments.
 	if len(t.data) > 0 {
-		specs := make([]ast.Spec, len(t.data))
-		for i, seg := range t.data {
-			specs[i] = &ast.ValueSpec{
-				Names: []*ast.Ident{dataID(i)},
-				Values: []ast.Expr{&ast.BasicLit{
-					Kind:  token.STRING,
-					Value: strconv.Quote(string(seg.init)),
-				}},
+		if *embed != "" {
+			embedDecl := &ast.GenDecl{
+				Tok: token.VAR,
+				Doc: &ast.CommentGroup{
+					List: []*ast.Comment{{Text: "//go:embed " + *embed}},
+				},
+				Specs: []ast.Spec{
+					&ast.ValueSpec{
+						Names: []*ast.Ident{newID("data")},
+						Type:  newID("string"),
+					},
+				},
 			}
+			t.out.Decls = append(t.out.Decls, embedDecl)
+		} else {
+			specs := make([]ast.Spec, len(t.data))
+			for i, seg := range t.data {
+				specs[i] = &ast.ValueSpec{
+					Names: []*ast.Ident{dataID(i)},
+					Values: []ast.Expr{&ast.BasicLit{
+						Kind:  token.STRING,
+						Value: strconv.Quote(string(seg.init)),
+					}},
+				}
+			}
+			t.out.Decls = append(t.out.Decls, &ast.GenDecl{Tok: token.CONST, Specs: specs})
 		}
-		t.out.Decls = append(t.out.Decls, &ast.GenDecl{Tok: token.CONST, Specs: specs})
 	}
 
 	util.RemoveParens(&t.out)
@@ -1842,7 +1903,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 						Fun: newID("memory_init"),
 						Args: []ast.Expr{
 							t.memory.selector,
-							dataID(i), dst, src, n}}})
+							t.dataExpr(int(i)), dst, src, n}}})
 
 			case 0x09: // data.drop
 				// No-op since data segments are constants.
@@ -2120,7 +2181,9 @@ func (t *translator) readDataSection() error {
 		return err
 	}
 
-	t.data = make([]dataSegment, count)
+	if int(count) >= len(t.data) {
+		t.data = append(t.data, make([]dataSegment, int(count)-len(t.data))...)
+	}
 	for i := range t.data {
 		if tag, err := readLEB128(t.in); err != nil {
 			return err

--- a/translate.go
+++ b/translate.go
@@ -188,15 +188,18 @@ func translate(r io.Reader, w io.Writer) error {
 			}
 			t.out.Decls = append(t.out.Decls, embedDecl)
 		} else {
-			specs := make([]ast.Spec, len(t.data))
+			var specs []ast.Spec
 			for i, seg := range t.data {
-				specs[i] = &ast.ValueSpec{
+				if seg.merged {
+					continue
+				}
+				specs = append(specs, &ast.ValueSpec{
 					Names: []*ast.Ident{dataID(i)},
 					Values: []ast.Expr{&ast.BasicLit{
 						Kind:  token.STRING,
 						Value: strconv.Quote(string(seg.init)),
 					}},
-				}
+				})
 			}
 			t.out.Decls = append(t.out.Decls, &ast.GenDecl{Tok: token.CONST, Specs: specs})
 		}
@@ -1088,7 +1091,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 						&ast.CaseClause{Body: fn.branch(target)})
 				}
 
-				caseExpr := &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(i, 10)}
+				caseExpr := &ast.BasicLit{Kind: token.INT, Value: formatUint(i)}
 				caseClse := sw.Body.List[id].(*ast.CaseClause)
 				caseClse.List = append(caseClse.List, caseExpr)
 			}
@@ -1954,7 +1957,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 							tab,
 							&ast.IndexExpr{
 								X:     &ast.SelectorExpr{X: newID("m"), Sel: newID("elements")},
-								Index: &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(elemIdx, 10)}},
+								Index: &ast.BasicLit{Kind: token.INT, Value: formatUint(elemIdx)}},
 							dst, src, n}}})
 
 			case 0x0d: // elem.drop
@@ -1966,7 +1969,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 					Tok: token.ASSIGN,
 					Lhs: []ast.Expr{&ast.IndexExpr{
 						X:     &ast.SelectorExpr{X: newID("m"), Sel: newID("elements")},
-						Index: &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(idx, 10)}}},
+						Index: &ast.BasicLit{Kind: token.INT, Value: formatUint(idx)}}},
 					Rhs: []ast.Expr{newID("nil")}})
 
 			case 0x0e: // table.copy
@@ -2155,6 +2158,14 @@ func (t *translator) readDataSection() error {
 		t.data = append(t.data, make([]dataSegment, int(count)-len(t.data))...)
 	}
 
+	var (
+		threshold  int64 = 64
+		lastActive int   = -1
+		lastDest   int64
+		lastSize   int64
+		fileOffset int64
+	)
+
 	var f *os.File
 	if *embed != "" {
 		f, err = os.Create(*embed)
@@ -2162,13 +2173,9 @@ func (t *translator) readDataSection() error {
 			return err
 		}
 		defer f.Close()
+		threshold = 4096
 		t.packages.add("embed")
 	}
-
-	var offset uint64
-	var lastActive int = -1
-	var lastDest int64
-	var lastLen uint64
 
 	for i := range t.data {
 		if tag, err := readLEB128(t.in); err != nil {
@@ -2179,8 +2186,7 @@ func (t *translator) readDataSection() error {
 			return fmt.Errorf("unsupported data segment tag: %d", tag)
 		}
 
-		var dest int64
-		var isConst bool
+		var dest int64 = -1
 
 		if !t.data[i].passive {
 			expr, err := t.readConstExpr()
@@ -2190,10 +2196,8 @@ func (t *translator) readDataSection() error {
 			t.data[i].offset = expr
 			if v, ok := islit(expr, "i32"); ok {
 				dest = v
-				isConst = true
 			} else if v, ok := islit(expr, "i64"); ok {
 				dest = v
-				isConst = true
 			}
 		}
 
@@ -2201,50 +2205,60 @@ func (t *translator) readDataSection() error {
 		if err != nil {
 			return err
 		}
+		size := int64(numElems)
+
+		if dest >= 0 && lastActive >= 0 {
+			gap := dest - (lastDest + lastSize)
+			if 0 <= gap && gap < threshold {
+				if f == nil {
+					data := &t.data[lastActive]
+					data.init = append(data.init, make([]byte, gap)...)
+					buf := make([]byte, size)
+					if _, err := io.ReadFull(t.in, buf); err != nil {
+						return err
+					}
+					data.init = append(data.init, buf...)
+				} else {
+					if _, err := f.Write(make([]byte, gap)); err != nil {
+						return err
+					}
+					fileOffset += gap
+					if _, err := io.CopyN(f, t.in, size); err != nil {
+						return err
+					}
+					fileOffset += size
+					t.dataExpr(lastActive).X.(*ast.SliceExpr).High.(*ast.BasicLit).Value = formatInt(fileOffset)
+				}
+				t.data[i].merged = true
+				lastSize += gap + size
+				continue
+			}
+		}
+
 		if f == nil {
-			t.data[i].init = make([]byte, numElems)
-			if _, err := io.ReadFull(t.in, t.data[i].init); err != nil {
+			data := &t.data[i]
+			data.init = make([]byte, size)
+			if _, err := io.ReadFull(t.in, data.init); err != nil {
 				return err
 			}
 		} else {
-			if isConst && lastActive >= 0 {
-				gap := dest - (lastDest + int64(lastLen))
-				if gap >= 0 && gap < 4096 { // Limit the zero-padding to 4KB
-					if gap > 0 {
-						if _, err := f.Write(make([]byte, gap)); err != nil {
-							return err
-						}
-						offset += uint64(gap)
-					}
-					if _, err := io.CopyN(f, t.in, int64(numElems)); err != nil {
-						return err
-					}
-					offset += numElems
-					lastLen += uint64(gap) + numElems
-					t.dataExpr(lastActive).X.(*ast.SliceExpr).High.(*ast.BasicLit).Value = strconv.FormatUint(offset, 10)
-					t.data[i].merged = true
-					continue
-				}
-			}
-
-			_, err := io.CopyN(f, t.in, int64(numElems))
-			if err != nil {
+			if _, err := io.CopyN(f, t.in, size); err != nil {
 				return err
 			}
 			t.dataExpr(i).X = &ast.SliceExpr{
 				X:    newID("data"),
-				Low:  &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset, 10)},
-				High: &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset+numElems, 10)},
+				Low:  &ast.BasicLit{Kind: token.INT, Value: formatInt(fileOffset)},
+				High: &ast.BasicLit{Kind: token.INT, Value: formatInt(fileOffset + size)},
 			}
-			offset += numElems
+			fileOffset += size
+		}
 
-			if isConst {
-				lastActive = i
-				lastDest = dest
-				lastLen = numElems
-			} else {
-				lastActive = -1 // Break contiguous chain if dynamically offset
-			}
+		if dest >= 0 {
+			lastDest = dest
+			lastSize = size
+			lastActive = i
+		} else {
+			lastActive = -1
 		}
 	}
 

--- a/translate.go
+++ b/translate.go
@@ -95,34 +95,6 @@ func translate(r io.Reader, w io.Writer) error {
 		}
 	}
 
-	if *embed == "" || len(t.data) == 0 {
-		for i := range t.data {
-			t.dataExpr(i).X = dataID(i)
-		}
-	} else {
-		f, err := os.Create(*embed)
-		if err != nil {
-			return err
-		}
-		var offset int
-		for i, seg := range t.data {
-			n, err := f.Write(seg.init)
-			if err != nil {
-				f.Close()
-				return err
-			}
-			t.dataExpr(i).X = &ast.SliceExpr{
-				X:    newID("data"),
-				Low:  &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(offset)},
-				High: &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(offset + n)},
-			}
-			offset += n
-		}
-		if err := f.Close(); err != nil {
-			return err
-		}
-	}
-
 	exported := false
 	for _, exp := range t.exports {
 		if exp.kind == externMemory {
@@ -186,15 +158,13 @@ func translate(r io.Reader, w io.Writer) error {
 	if len(t.packages) > 0 {
 		specs := make([]ast.Spec, 0, len(t.data))
 		for _, pkg := range slices.Sorted(maps.Keys(t.packages)) {
-			specs = append(specs, &ast.ImportSpec{
+			spec := ast.ImportSpec{
 				Path: &ast.BasicLit{Kind: token.STRING, Value: `"` + pkg + `"`},
-			})
-		}
-		if *embed != "" && len(t.data) > 0 {
-			specs = append(specs, &ast.ImportSpec{
-				Name: newID("_"),
-				Path: &ast.BasicLit{Kind: token.STRING, Value: `"embed"`},
-			})
+			}
+			if pkg == "embed" {
+				spec.Name = newID("_")
+			}
+			specs = append(specs, &spec)
 		}
 		t.out.Decls = append([]ast.Decl{
 			&ast.GenDecl{Tok: token.IMPORT, Specs: specs}},
@@ -2184,6 +2154,18 @@ func (t *translator) readDataSection() error {
 	if int(count) >= len(t.data) {
 		t.data = append(t.data, make([]dataSegment, int(count)-len(t.data))...)
 	}
+
+	var f *os.File
+	if *embed != "" {
+		f, err = os.Create(*embed)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		t.packages.add("embed")
+	}
+
+	var offset uint64
 	for i := range t.data {
 		if tag, err := readLEB128(t.in); err != nil {
 			return err
@@ -2205,10 +2187,27 @@ func (t *translator) readDataSection() error {
 		if err != nil {
 			return err
 		}
-		t.data[i].init = make([]byte, numElems)
-		if _, err := io.ReadFull(t.in, t.data[i].init); err != nil {
-			return err
+		if f == nil {
+			t.data[i].init = make([]byte, numElems)
+			if _, err := io.ReadFull(t.in, t.data[i].init); err != nil {
+				return err
+			}
+		} else {
+			_, err := io.CopyN(f, t.in, int64(numElems))
+			if err != nil {
+				return err
+			}
+			t.dataExpr(i).X = &ast.SliceExpr{
+				X:    newID("data"),
+				Low:  &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset, 10)},
+				High: &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset+numElems, 10)},
+			}
+			offset += numElems
 		}
+	}
+
+	if f != nil {
+		return f.Close()
 	}
 	return nil
 }

--- a/translate.go
+++ b/translate.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -173,11 +174,11 @@ func translate(r io.Reader, w io.Writer) error {
 
 	// Add data segments.
 	if len(t.data) > 0 {
-		if *embed != "" {
+		if *embed {
 			embedDecl := &ast.GenDecl{
 				Tok: token.VAR,
 				Doc: &ast.CommentGroup{
-					List: []*ast.Comment{{Text: "//go:embed " + *embed}},
+					List: []*ast.Comment{{Text: "//go:embed " + filepath.Base(embedFile)}},
 				},
 				Specs: []ast.Spec{
 					&ast.ValueSpec{
@@ -2167,8 +2168,8 @@ func (t *translator) readDataSection() error {
 	)
 
 	var f *os.File
-	if *embed != "" {
-		f, err = os.Create(*embed)
+	if *embed {
+		f, err = os.Create(embedFile)
 		if err != nil {
 			return err
 		}

--- a/translate.go
+++ b/translate.go
@@ -68,7 +68,7 @@ func (t *translator) dataExpr(i int) *ast.ParenExpr {
 		t.data = append(t.data, make([]dataSegment, i+1-len(t.data))...)
 	}
 	if t.data[i].embed == nil {
-		t.data[i].embed = &ast.ParenExpr{}
+		t.data[i].embed = &ast.ParenExpr{X: dataID(i)}
 	}
 	return t.data[i].embed
 }

--- a/translate.go
+++ b/translate.go
@@ -2166,6 +2166,10 @@ func (t *translator) readDataSection() error {
 	}
 
 	var offset uint64
+	var lastActive int = -1
+	var lastDest int64
+	var lastLen uint64
+
 	for i := range t.data {
 		if tag, err := readLEB128(t.in); err != nil {
 			return err
@@ -2175,12 +2179,22 @@ func (t *translator) readDataSection() error {
 			return fmt.Errorf("unsupported data segment tag: %d", tag)
 		}
 
+		var dest int64
+		var isConst bool
+
 		if !t.data[i].passive {
 			expr, err := t.readConstExpr()
 			if err != nil {
 				return err
 			}
 			t.data[i].offset = expr
+			if v, ok := islit(expr, "i32"); ok {
+				dest = v
+				isConst = true
+			} else if v, ok := islit(expr, "i64"); ok {
+				dest = v
+				isConst = true
+			}
 		}
 
 		numElems, err := readLEB128(t.in)
@@ -2193,6 +2207,26 @@ func (t *translator) readDataSection() error {
 				return err
 			}
 		} else {
+			if isConst && lastActive >= 0 {
+				gap := dest - (lastDest + int64(lastLen))
+				if gap >= 0 && gap < 4096 { // Limit the zero-padding to 4KB
+					if gap > 0 {
+						if _, err := f.Write(make([]byte, gap)); err != nil {
+							return err
+						}
+						offset += uint64(gap)
+					}
+					if _, err := io.CopyN(f, t.in, int64(numElems)); err != nil {
+						return err
+					}
+					offset += numElems
+					lastLen += uint64(gap) + numElems
+					t.dataExpr(lastActive).X.(*ast.SliceExpr).High.(*ast.BasicLit).Value = strconv.FormatUint(offset, 10)
+					t.data[i].merged = true
+					continue
+				}
+			}
+
 			_, err := io.CopyN(f, t.in, int64(numElems))
 			if err != nil {
 				return err
@@ -2203,6 +2237,14 @@ func (t *translator) readDataSection() error {
 				High: &ast.BasicLit{Kind: token.INT, Value: strconv.FormatUint(offset+numElems, 10)},
 			}
 			offset += numElems
+
+			if isConst {
+				lastActive = i
+				lastDest = dest
+				lastLen = numElems
+			} else {
+				lastActive = -1 // Break contiguous chain if dynamically offset
+			}
 		}
 	}
 

--- a/translate.go
+++ b/translate.go
@@ -64,16 +64,6 @@ type translator struct {
 	data      []dataSegment
 }
 
-func (t *translator) dataExpr(i int) *ast.ParenExpr {
-	if i >= len(t.data) {
-		t.data = append(t.data, make([]dataSegment, i+1-len(t.data))...)
-	}
-	if t.data[i].embed == nil {
-		t.data[i].embed = &ast.ParenExpr{X: dataID(i)}
-	}
-	return t.data[i].embed
-}
-
 func translate(r io.Reader, w io.Writer) error {
 	var t translator
 
@@ -2269,17 +2259,6 @@ func (t *translator) readDataSection() error {
 	return nil
 }
 
-func (t *translator) resolveImports(n ast.Node) bool {
-	if sel, ok := n.(*ast.SelectorExpr); ok {
-		if id, ok := sel.X.(*ast.Ident); ok {
-			if path, ok := stdlib[id.Name]; ok {
-				t.packages.add(path)
-			}
-		}
-	}
-	return true
-}
-
 func (t *translator) readCustomSection(size int) error {
 	data := make([]byte, size)
 	if _, err := io.ReadFull(t.in, data); err != nil {
@@ -2372,4 +2351,25 @@ func (t *translator) readNameSection(r *bytes.Reader) error {
 		}
 	}
 	return nil
+}
+
+func (t *translator) resolveImports(n ast.Node) bool {
+	if sel, ok := n.(*ast.SelectorExpr); ok {
+		if id, ok := sel.X.(*ast.Ident); ok {
+			if path, ok := stdlib[id.Name]; ok {
+				t.packages.add(path)
+			}
+		}
+	}
+	return true
+}
+
+func (t *translator) dataExpr(i int) *ast.ParenExpr {
+	if i >= len(t.data) {
+		t.data = append(t.data, make([]dataSegment, i+1-len(t.data))...)
+	}
+	if t.data[i].embed == nil {
+		t.data[i].embed = &ast.ParenExpr{X: dataID(i)}
+	}
+	return t.data[i].embed
 }

--- a/types.go
+++ b/types.go
@@ -156,6 +156,7 @@ type elemSegment struct {
 type dataSegment struct {
 	init    []byte
 	offset  ast.Expr
+	embed   *ast.ParenExpr
 	passive bool
 }
 

--- a/types.go
+++ b/types.go
@@ -158,6 +158,7 @@ type dataSegment struct {
 	offset  ast.Expr
 	embed   *ast.ParenExpr
 	passive bool
+	merged  bool
 }
 
 type nameSubsection byte


### PR DESCRIPTION
Someone tried to convert [zeroperl](https://github.com/6over3/zeroperl), which has 21MB in 11k data sections.

This is a prototype alternate encoding for data sections using `go:embed`.