### PR TITLE
Provide imports

### DIFF
--- a/fncompiler.go
+++ b/fncompiler.go
@@ -20,6 +20,8 @@ type funcCompiler struct {
 	blocks stack[funcBlock]
 	labels int
 	temps  int
+
+	provided bool
 }
 
 type entryKind int

--- a/main.go
+++ b/main.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	output   = flag.String("o", "", "output file (default stdout)")
-	provided = flag.String("provided", "", "file containing provided import functions")
+	output = flag.String("o", "", "output file (default stdout)")
 
 	embed  = flag.Bool("embed", false, "go:embed data sections from a .dat file")
 	nanbox = flag.Bool("nanbox", false, "whether to try to canonicalize NaNs")
@@ -19,12 +18,14 @@ var (
 	noopt  = flag.Bool("noopt", false, "disable all optimization passes")
 	unsafe = flag.Bool("unsafe", false, "allow importing unsafe")
 
+	provided  stringFlags
 	embedFile string
 )
 
 func main() {
 	log.SetFlags(0)
 
+	flag.Var(&provided, "provided", "file containing provided import functions")
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] [input.wasm]\n", os.Args[0])
 		flag.PrintDefaults()
@@ -69,4 +70,15 @@ func main() {
 	if err := out.Close(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+type stringFlags []string
+
+func (l *stringFlags) String() string {
+	return strings.Join(*l, ", ")
+}
+
+func (l *stringFlags) Set(value string) error {
+	*l = append(*l, value)
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	output = flag.String("o", "", "output file (default stdout)")
+	output   = flag.String("o", "", "output file (default stdout)")
+	provided = flag.String("provided", "", "file containing provided import functions")
 
 	embed  = flag.Bool("embed", false, "go:embed data sections from a .dat file")
 	nanbox = flag.Bool("nanbox", false, "whether to try to canonicalize NaNs")

--- a/module.go
+++ b/module.go
@@ -34,11 +34,10 @@ func (t *translator) createModuleStruct() ast.Decl {
 	// Memory: owned a []byte; imported a *[]byte and a Memory field.
 	if t.memory != nil {
 		if t.memory.imported {
-			id := newID("Memory")
 			fields = append(fields, &ast.Field{
 				Names: []*ast.Ident{t.memory.id},
 				Type:  &ast.StarExpr{X: &ast.ArrayType{Elt: newID("byte")}},
-			}, &ast.Field{Names: []*ast.Ident{id}, Type: id})
+			}, &ast.Field{Names: []*ast.Ident{newID("memImp")}, Type: newID("Memory")})
 		} else {
 			fields = append(fields, &ast.Field{
 				Names: []*ast.Ident{t.memory.id},
@@ -173,9 +172,10 @@ func (t *translator) createNewFunc() ast.Decl {
 						Sel: util.MangleID(imp.name, util.IDExported)}}}})
 
 		case externMemory:
+			expr := &ast.SelectorExpr{X: newID("m"), Sel: newID("memImp")}
 			body.List = append(body.List, &ast.AssignStmt{
 				Tok: token.ASSIGN,
-				Lhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID("Memory")}},
+				Lhs: []ast.Expr{expr},
 				Rhs: []ast.Expr{&ast.CallExpr{
 					Fun: &ast.SelectorExpr{
 						X:   locals[imp.module],
@@ -183,8 +183,7 @@ func (t *translator) createNewFunc() ast.Decl {
 			}, &ast.AssignStmt{
 				Tok: token.ASSIGN,
 				Lhs: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: t.memory.id}},
-				Rhs: []ast.Expr{&ast.CallExpr{
-					Fun: &ast.SelectorExpr{X: &ast.SelectorExpr{X: newID("m"), Sel: newID("Memory")}, Sel: newID("Slice")}}}})
+				Rhs: []ast.Expr{&ast.CallExpr{Fun: &ast.SelectorExpr{X: expr, Sel: newID("Slice")}}}})
 		}
 	}
 
@@ -430,7 +429,7 @@ func (t *translator) createExportMethods() []ast.Decl {
 		case externMemory:
 			decl.Type.Results = &ast.FieldList{List: []*ast.Field{{Type: newID("Memory")}}}
 			if t.memory.imported {
-				decl.Body.List = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID("Memory")}}}}
+				decl.Body.List = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.SelectorExpr{X: newID("m"), Sel: newID("memImp")}}}}
 			} else {
 				decl.Body.List = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{&ast.CallExpr{
 					Fun:  &ast.ParenExpr{X: &ast.StarExpr{X: newID("wasmMemory")}},

--- a/samples_test.go
+++ b/samples_test.go
@@ -127,9 +127,7 @@ func Test_table(t *testing.T) {
 
 type tableEnv struct{}
 
-func (t tableEnv) Xjstimes3(v0 int32) int32 {
-	return v0 * 3
-}
+func (t tableEnv) Xjstimes3(v0 int32) int32 { return v0 * 3 }
 
 func Test_trig(t *testing.T) {
 	want := []float32{
@@ -156,15 +154,15 @@ func Test_trig(t *testing.T) {
 }
 
 func Test_loops(t *testing.T) {
-	m := loops_test.New(loopsEnv{})
-	mem := *m.Memory.Slice()
+	env := new(loopsEnv)
+	m := loops_test.New(env)
 
 	var want int
 	const count = 50
 	const start = 128
 	// Initialize data in memory.
 	for i := range count {
-		binary.LittleEndian.PutUint32(mem[start+i*4:], uint32(i*2-1))
+		binary.LittleEndian.PutUint32(env.mem[start+i*4:], uint32(i*2-1))
 		want += i*2 - 1
 	}
 
@@ -200,13 +198,11 @@ type loopsEnv struct {
 	mem [65536]byte
 }
 
-func (e loopsEnv) Xbuffer() loops_test.Memory {
-	return &e
-}
+func (e *loopsEnv) Xbuffer() loops_test.Memory { return e }
 
-func (loopsEnv) Xlog_i32(v0 int32) {}
+func (e *loopsEnv) Xlog_i32(v0 int32) {}
 
-func (loopsEnv) Xrand_i32() int32 { return rand.Int31n(10000) }
+func (e *loopsEnv) Xrand_i32() int32 { return rand.Int31n(10000) }
 
 func (e *loopsEnv) Slice() *[]byte { b := e.mem[:]; return &b }
 

--- a/testdata/loops/loops.go
+++ b/testdata/loops/loops.go
@@ -6,7 +6,7 @@ import "encoding/binary"
 
 type Module struct {
 	memory *[]byte
-	Memory Memory
+	memImp Memory
 	maxMem int64
 	_env   Xenv
 }
@@ -15,8 +15,8 @@ func New(v0 Xenv) *Module {
 	m := &Module{}
 	m._env = v0
 	m.maxMem = 65536
-	m.Memory = v0.Xbuffer()
-	m.memory = m.Memory.Slice()
+	m.memImp = v0.Xbuffer()
+	m.memory = m.memImp.Slice()
 	if i, ok := any(v0).(interface {
 		Init(any)
 	}); ok {

--- a/translate.go
+++ b/translate.go
@@ -55,6 +55,7 @@ type translator struct {
 	out ast.File
 	// Dependencies.
 	packages set[string]
+	provided set[string]
 	helpers  set[string]
 	// Sections.
 	types     []funcType
@@ -80,7 +81,21 @@ func translate(r io.Reader, w io.Writer) error {
 	}
 
 	t.packages = set[string]{}
+	t.provided = set[string]{}
 	t.helpers = set[string]{}
+
+	if provided != nil && *provided != "" {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, *provided, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, decl := range f.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv != nil {
+				t.provided.add(fn.Name.Name)
+			}
+		}
+	}
 
 	// Load Wasm.
 	for {
@@ -395,6 +410,19 @@ func (t *translator) readImportSection() error {
 				return err
 			}
 			typ := t.types[index]
+
+			internalName := util.Mangle(name, util.IDInternal)
+			if t.provided.has(internalName) {
+				id := newID(internalName)
+				fn := funcCompiler{
+					typ:      typ,
+					decl:     &ast.FuncDecl{Name: id},
+					call:     &ast.ParenExpr{X: &ast.SelectorExpr{X: newID("m"), Sel: id}},
+					provided: true}
+				t.functions = append(t.functions, fn)
+				continue
+			}
+
 			t.imports = append(t.imports, importDef{
 				module: mod,
 				name:   name,
@@ -760,7 +788,9 @@ func (t *translator) readExportSection() error {
 		switch externKind(kind) {
 		case externFunction:
 			decl := t.functions[index].decl
-			decl.Name.Name = util.Mangle(name, util.IDExported)
+			if !t.functions[index].provided {
+				decl.Name.Name = util.Mangle(name, util.IDExported)
+			}
 		}
 	}
 	return nil
@@ -782,12 +812,7 @@ func (t *translator) readCodeSection() error {
 		return err
 	}
 
-	var importedFuncs uint64
-	for _, imp := range t.imports {
-		if imp.kind == externFunction {
-			importedFuncs++
-		}
-	}
+	importedFuncs := uint64(len(t.functions)) - numFuncs
 
 	for i := range numFuncs {
 		i += importedFuncs

--- a/translate.go
+++ b/translate.go
@@ -1525,7 +1525,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			if fn.memory.imported {
 				fn.push(convert(&ast.CallExpr{
 					Fun: &ast.SelectorExpr{
-						X:   &ast.SelectorExpr{X: newID("m"), Sel: newID("Memory")},
+						X:   &ast.SelectorExpr{X: newID("m"), Sel: newID("memImp")},
 						Sel: newID("Grow")},
 					Args: []ast.Expr{
 						convert(fn.pop(), "int64"),

--- a/translate.go
+++ b/translate.go
@@ -80,21 +80,19 @@ func translate(r io.Reader, w io.Writer) error {
 		return err
 	}
 
+	fset := token.NewFileSet()
 	t.packages = set[string]{}
 	t.provided = set[string]{}
 	t.helpers = set[string]{}
 
-	if len(provided) > 0 {
-		fset := token.NewFileSet()
-		for _, file := range provided {
-			f, err := parser.ParseFile(fset, file, nil, 0)
-			if err != nil {
-				return err
-			}
-			for _, decl := range f.Decls {
-				if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv != nil {
-					t.provided.add(fn.Name.Name)
-				}
+	for _, file := range provided {
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			return err
+		}
+		for _, decl := range f.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv != nil {
+				t.provided.add(fn.Name.Name)
 			}
 		}
 	}
@@ -157,7 +155,6 @@ func translate(r io.Reader, w io.Writer) error {
 	t.out.Decls = append(t.out.Decls, t.createExportMethods()...)
 
 	// Add helpers.
-	fset := token.NewFileSet()
 	if len(t.helpers) > 0 {
 		if *unsafe {
 			f, err := parser.ParseFile(fset, "helpers_unsafe.go", helpersUnsafeSrc, parser.ParseComments)
@@ -413,9 +410,8 @@ func (t *translator) readImportSection() error {
 			}
 			typ := t.types[index]
 
-			internalName := util.Mangle(name, util.IDInternal)
-			if t.provided.has(internalName) {
-				id := newID(internalName)
+			if n := util.Mangle(name, util.IDInternal); t.provided.has(n) {
+				id := ast.NewIdent(n)
 				fn := funcCompiler{
 					typ:      typ,
 					decl:     &ast.FuncDecl{Name: id},
@@ -789,8 +785,8 @@ func (t *translator) readExportSection() error {
 
 		switch externKind(kind) {
 		case externFunction:
-			decl := t.functions[index].decl
 			if !t.functions[index].provided {
+				decl := t.functions[index].decl
 				decl.Name.Name = util.Mangle(name, util.IDExported)
 			}
 		}

--- a/translate.go
+++ b/translate.go
@@ -91,8 +91,13 @@ func translate(r io.Reader, w io.Writer) error {
 			return err
 		}
 		for _, decl := range f.Decls {
+			// Check if the receiver type is *Module.
 			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv != nil {
-				t.provided.add(fn.Name.Name)
+				if star, ok := fn.Recv.List[0].Type.(*ast.StarExpr); ok {
+					if id, ok := star.X.(*ast.Ident); ok && id.Name == "Module" {
+						t.provided.add(fn.Name.Name)
+					}
+				}
 			}
 		}
 	}

--- a/translate.go
+++ b/translate.go
@@ -84,15 +84,17 @@ func translate(r io.Reader, w io.Writer) error {
 	t.provided = set[string]{}
 	t.helpers = set[string]{}
 
-	if provided != nil && *provided != "" {
+	if len(provided) > 0 {
 		fset := token.NewFileSet()
-		f, err := parser.ParseFile(fset, *provided, nil, 0)
-		if err != nil {
-			return err
-		}
-		for _, decl := range f.Decls {
-			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv != nil {
-				t.provided.add(fn.Name.Name)
+		for _, file := range provided {
+			f, err := parser.ParseFile(fset, file, nil, 0)
+			if err != nil {
+				return err
+			}
+			for _, decl := range f.Decls {
+				if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv != nil {
+					t.provided.add(fn.Name.Name)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Adds a command line flag, `-provide file.go` (can be specified repeatedly). `file.go` can contain methods of the `Module` structure, and those will be used to override imports.