### PR TITLE
add new SimplifyGotos() optimization pass

### DIFF
--- a/fncompiler.go
+++ b/fncompiler.go
@@ -589,6 +589,7 @@ func (fn *funcCompiler) cleanup() {
 	if !*noopt {
 		util.UnnestBlocks(fn.decl)
 		util.RemoveEmptyStmts(fn.decl)
+		util.SimplifyGotos(fn.decl)
 		util.RemoveSelfAssign(fn.decl)
 		util.RemoveBlankAssigns(fn.decl)
 		if util.RemoveReceiver(fn.decl) {

--- a/testdata/loops/loops.go
+++ b/testdata/loops/loops.go
@@ -55,7 +55,6 @@ l1:
 		v2 = v2 + i32(1)
 		goto l1
 	}
-	return v4
 }
 func (m *Module) Xrand_multiple_of_10() int32 {
 	var v0 int32
@@ -75,7 +74,6 @@ l1:
 	}
 	v2 = v2 * v0
 	goto l1
-	return v2
 }
 
 //go:nosplit

--- a/testdata/loops/loops.go
+++ b/testdata/loops/loops.go
@@ -47,7 +47,7 @@ func (m *Module) Xadd_all(v0, v1 int32) int32 {
 l1:
 	{
 		if v2 >= v1 {
-			goto l0
+			return v4
 		}
 		v3 = v0 + v2*i32(4)
 		t0 := v4
@@ -55,7 +55,6 @@ l1:
 		v2 = v2 + i32(1)
 		goto l1
 	}
-l0:
 	return v4
 }
 func (m *Module) Xrand_multiple_of_10() int32 {
@@ -72,11 +71,10 @@ func (m *Module) Xfirst_power_over_limit(v0, v1 int32) int32 {
 	v2 = i32(1)
 l1:
 	if v2 > v1 {
-		goto l0
+		return v2
 	}
 	v2 = v2 * v0
 	goto l1
-l0:
 	return v2
 }
 

--- a/testdata/primes/primes.go
+++ b/testdata/primes/primes.go
@@ -23,15 +23,13 @@ func (m *Module) Xis_prime(v0 int32) int32 {
 	v1 = i32(3)
 l1:
 	if uint32(v1) >= uint32(v0) {
-		goto l0
+		return i32(1)
 	}
 	if int32(uint32(v0)%uint32(v1)) == i32(0) {
 		return i32(0)
 	}
 	v1 = v1 + i32(2)
 	goto l1
-l0:
-	return i32(1)
 }
 
 //go:nosplit

--- a/testdata/trig/trig.go
+++ b/testdata/trig/trig.go
@@ -42,7 +42,7 @@ func (m *Module) Xsin(v0 float64) float64 {
 l0:
 	v1 = math.Float64frombits(0x7ff8000000000000)
 	if int64(math.Float64bits(v0))&i64(0x7fffffffffffffff) > i64(0x7fefffffffffffff) {
-		goto l1
+		return v1
 	}
 	v1 = float64(float64(v0*float64(0.6366197723675814)) + math.Copysign(float64(0.5), v0))
 	if !(math.Abs(v1) < float64(0x1p+63)) {
@@ -66,13 +66,13 @@ l9:
 	}
 	switch int32(v2) & i32(3) {
 	case 1:
-		goto l6
+		return v4
 	case 2:
 		goto l7
 	case 3:
 		goto l8
 	default:
-		goto l1
+		return v1
 	}
 l5:
 	v3 = v3 + i32(-1)
@@ -81,18 +81,15 @@ l5:
 	v1 = float64(v1 + v1)
 	v4 = float64(float64(1) - float64(v0+v0))
 	goto l9
-l6:
-	return v4
 l7:
 	return -v1
 l8:
 	v1 = -v4
-	goto l1
+	return v1
 l4:
 	v3 = v3 + i32(1)
 	v1 = float64(v1 * float64(0.5))
 	goto l10
-l1:
 	return v1
 }
 func (m *Module) Xmemory() Memory {

--- a/testdata/trig/trig.go
+++ b/testdata/trig/trig.go
@@ -90,7 +90,6 @@ l4:
 	v3 = v3 + i32(1)
 	v1 = float64(v1 * float64(0.5))
 	goto l10
-	return v1
 }
 func (m *Module) Xmemory() Memory {
 	return (*wasmMemory)(&m.memory)

--- a/testdata/trig/trig.go
+++ b/testdata/trig/trig.go
@@ -68,7 +68,7 @@ l9:
 	case 1:
 		return v4
 	case 2:
-		goto l7
+		return -v1
 	case 3:
 		goto l8
 	default:
@@ -81,8 +81,6 @@ l5:
 	v1 = float64(v1 + v1)
 	v4 = float64(float64(1) - float64(v0+v0))
 	goto l9
-l7:
-	return -v1
 l8:
 	v1 = -v4
 	return v1

--- a/translate_test.go
+++ b/translate_test.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,8 @@ import (
 
 //go:generate go test -run translate -args -unsafe
 //go:generate go test -run translate
+
+var runGopls = (os.Getenv("RUN_GOPLS") != "")
 
 func Test_translate(t *testing.T) {
 	tests := []string{"fib", "loops", "memory", "primes", "recursion", "stack", "table", "trig"}
@@ -34,9 +37,20 @@ func Test_translate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = os.WriteFile(path+".go", out.Bytes(), 0644)
+			gopath := path + ".go"
+
+			err = os.WriteFile(gopath, out.Bytes(), 0644)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if runGopls {
+				cmd := exec.Command("gopls", "check", "./"+gopath)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					panic(err)
+				}
 			}
 		})
 	}
@@ -66,7 +80,9 @@ func Test_translateSpecTest(t *testing.T) {
 				return nil
 			}
 
-			err = os.WriteFile(strings.TrimRight(path, ext)+".go", out.Bytes(), 0644)
+			gopath := strings.TrimRight(path, ext) + ".go"
+
+			err = os.WriteFile(gopath, out.Bytes(), 0644)
 			if err != nil {
 				t.Errorf("%s: %v", path, err)
 				return nil
@@ -76,6 +92,15 @@ func Test_translateSpecTest(t *testing.T) {
 			if err != nil {
 				t.Errorf("%s: %v", path, err)
 				return nil
+			}
+
+			if runGopls {
+				cmd := exec.Command("gopls", "check", "./"+gopath)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					panic(err)
+				}
 			}
 		}
 		return nil

--- a/util/opt.go
+++ b/util/opt.go
@@ -267,6 +267,11 @@ func RemoveParens(n ast.Node) {
 //   - a labeled statement consisting of only a "simple" return.
 //     where fallthrough can be definitively ruled-out, the labeled
 //     return will also be deleted from the funtion block.
+//
+//   - a labeled statement consisting of only a "complex" return,
+//     specifically where fallthrough is definitively ruled-out and
+//     there is only one usage of the label. i.e. won't increase
+//     function complexity by inlining multiple "complex" returns.
 func SimplifyGotos(fn *ast.FuncDecl) {
 	type labeledReturn struct {
 		Stmt   *ast.ReturnStmt
@@ -319,7 +324,7 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 	})
 
 	// Filter out any without a return set,
-	// i.e. labeled non-single-return blocks.
+	// i.e. labeled non-returning blocks.
 	for label, ret := range returns {
 		if ret.Stmt == nil {
 			delete(returns, label)
@@ -395,10 +400,6 @@ func cannotFallthrough(n ast.Node) bool {
 		return true
 
 	case *ast.BranchStmt:
-		// Anything other than GOTO isn't
-		// expected to be passed to this
-		// function, or needs more granular
-		// handling in a cannotBreak() func.
 		return n.Tok == token.GOTO
 
 	case *ast.BlockStmt:
@@ -480,6 +481,7 @@ func cannotBreak[T any](list []T) bool {
 		// Some simple types
 		// we know don't break.
 		case *ast.CallExpr:
+		case *ast.UnaryExpr:
 		case *ast.BinaryExpr:
 		case *ast.AssignStmt:
 		case *ast.ReturnStmt:
@@ -524,9 +526,6 @@ func isSimpleValue(n ast.Expr) bool {
 		return true
 	case *ast.UnaryExpr:
 		return isSimpleValue(n.X)
-	case *ast.BinaryExpr:
-		return isSimpleValue(n.X) &&
-			isSimpleValue(n.Y)
 	case *ast.CallExpr:
 		if len(n.Args) != 1 {
 			return false

--- a/util/opt.go
+++ b/util/opt.go
@@ -258,6 +258,40 @@ func RemoveParens(n ast.Node) {
 	})
 }
 
+// SimplifyGotos replaces all instances of "goto ${label}" with the contents
+// of its code block specifically where it only contains a return statement.
+func SimplifyGotos(root ast.Node) {
+	returns := make(map[string]*ast.ReturnStmt)
+
+	// First walk to find labelled statements that only contain
+	// a return, collecting the return and deleting the label.
+	astutil.Apply(root, nil, func(c *astutil.Cursor) bool {
+		switch n := c.Node().(type) {
+		case *ast.LabeledStmt:
+			switch s := n.Stmt.(type) {
+			case *ast.ReturnStmt:
+				returns[n.Label.Name] = s
+				c.Delete()
+			}
+		}
+		return true
+	})
+
+	// Second walk to replace all "goto ${label}" with return.
+	astutil.Apply(root, nil, func(c *astutil.Cursor) bool {
+		switch n := c.Node().(type) {
+		case *ast.BranchStmt:
+			if n.Tok == token.GOTO {
+				ret, ok := returns[n.Label.Name]
+				if ok {
+					c.Replace(ret)
+				}
+			}
+		}
+		return true
+	})
+}
+
 // countUses counts uses of an identifier.
 func countUses(n ast.Node) map[string]int {
 	uses := make(map[string]int)

--- a/util/opt.go
+++ b/util/opt.go
@@ -260,21 +260,36 @@ func RemoveParens(n ast.Node) {
 
 // SimplifyGotos replaces all instances of "goto ${label}" with
 // a return statement, specifically where labeled block matches:
-// - an empty labeled statement at the end of function body
-// - a labeled statement consisting of only a "simple" return
+//
+//   - an empty labeled statement at the end of function body,
+//     i.e. for valid AST this will be a function with no results
+//
+//   - a labeled statement consisting of only a "simple" return.
+//     where fallthrough can be definitively ruled-out, the labeled
+//     return will also be deleted from the funtion block.
 func SimplifyGotos(fn *ast.FuncDecl) {
 	returns := make(map[string]*ast.ReturnStmt)
 
-	// First walk to find labelled statements that only contain
-	// a return, collecting the return and deleting the label.
+	// First walk to find suitable labeled statements
+	// containing only a return, or empty at end of func.
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		p := c.Parent() // parent node
 		switch n := c.Node().(type) {
 		case *ast.LabeledStmt:
 			switch s := n.Stmt.(type) {
 			case *ast.ReturnStmt:
+
+				// Only try to "inline" this
+				// return if it's a return of
+				// "simple" values, otherwise
+				// this can increase function
+				// hairiness to the Go compiler.
 				if isSimpleReturn(s) {
 					returns[n.Label.Name] = s
+
+					// Only if this labeled return DEFINITIVELY
+					// cannot be fallen-through-to, do we remove
+					// it. Otherwise drop label and keep return.
 					if p := getPreviousInBlock(p, n); //
 					cannotFallthrough(p) {
 						c.Delete()
@@ -287,6 +302,10 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 				// If this is the last stmt in the function
 				// body and it's empty, all gotos can be
 				// replaced with a zero parameter return.
+				//
+				// We don't need to check for fallthroughs as unless this
+				// is invalid AST, reaching the end of the function block
+				// will be semantically equivalent to an empty return.
 				if fn.Body.List[len(fn.Body.List)-1] == n {
 					returns[n.Label.Name] = &ast.ReturnStmt{}
 					c.Delete()
@@ -296,7 +315,7 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 		return true
 	})
 
-	// Second walk to replace all "goto ${label}" with return.
+	// Second walk to replace matching labels with return.
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		switch n := c.Node().(type) {
 		case *ast.BranchStmt:

--- a/util/opt.go
+++ b/util/opt.go
@@ -258,9 +258,10 @@ func RemoveParens(n ast.Node) {
 	})
 }
 
-// SimplifyGotos replaces all instances of "goto ${label}" with the contents
-// of its code block specifically where it only contains a return statement,
-// or an empty statement and is the last in the function block.
+// SimplifyGotos replaces all instances of "goto ${label}" with
+// a return statement, specifically where labeled block matches:
+// - an empty labeled statement at the end of function body
+// - a labeled statement consisting of only a "simple" return
 func SimplifyGotos(fn *ast.FuncDecl) {
 	returns := make(map[string]*ast.ReturnStmt)
 
@@ -271,18 +272,20 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 		case *ast.LabeledStmt:
 			switch s := n.Stmt.(type) {
 			case *ast.ReturnStmt:
-				returns[n.Label.Name] = s
+				if isSimpleReturn(s) {
+					returns[n.Label.Name] = s
 
-				// If this isn't the last stmt in the function
-				// body, labeled return can safely be deleted.
-				if fn.Body.List[len(fn.Body.List)-1] != n {
-					c.Delete()
-					break
+					// If this isn't the last stmt in the function
+					// body, labeled return can safely be deleted.
+					if fn.Body.List[len(fn.Body.List)-1] != n {
+						c.Delete()
+						break
+					}
+
+					// Else just drop label
+					// and inline the return.
+					c.Replace(s)
 				}
-
-				// Else just drop label
-				// and inline the return.
-				c.Replace(s)
 
 			case *ast.EmptyStmt:
 				// If this is the last stmt in the function
@@ -300,8 +303,6 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 	// Second walk to replace all "goto ${label}" with return.
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		switch n := c.Node().(type) {
-		case *ast.LabeledStmt:
-
 		case *ast.BranchStmt:
 			if n.Tok == token.GOTO {
 				ret, ok := returns[n.Label.Name]
@@ -312,6 +313,39 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 		}
 		return true
 	})
+}
+
+// isSimpleReturn applies isSimpleValue() to each of the return's
+// result expressions, returning true only if all are simple.
+func isSimpleReturn(r *ast.ReturnStmt) bool {
+	for _, res := range r.Results {
+		if !isSimpleValue(res) {
+			return false
+		}
+	}
+	return true
+}
+
+// isSimpleValue returns whether given ast.Expr is
+// a simple value type, i.e. just a variable or literal,
+// taking int account any casting to primitive types.
+func isSimpleValue(n ast.Expr) bool {
+	switch n := n.(type) {
+	case *ast.Ident:
+		return true
+	case *ast.BasicLit:
+		return true
+	case *ast.CallExpr:
+		if len(n.Args) == 1 {
+			if id, ok := n.Fun.(*ast.Ident); ok &&
+				(strings.HasPrefix(id.Name, "int") ||
+					strings.HasPrefix(id.Name, "uint") ||
+					strings.HasPrefix(id.Name, "float")) {
+				return isSimpleValue(n.Args[0])
+			}
+		}
+	}
+	return false
 }
 
 // countUses counts uses of an identifier.

--- a/util/opt.go
+++ b/util/opt.go
@@ -268,59 +268,99 @@ func RemoveParens(n ast.Node) {
 //     where fallthrough can be definitively ruled-out, the labeled
 //     return will also be deleted from the funtion block.
 func SimplifyGotos(fn *ast.FuncDecl) {
-	returns := make(map[string]*ast.ReturnStmt)
+	type labeledReturn struct {
+		Stmt   *ast.ReturnStmt
+		NoFall bool
+		Simple bool
+		Uses   int
+	}
 
-	// First walk to find suitable labeled statements
-	// containing only a return, or empty at end of func.
+	// Gather labeled return information by name.
+	returns := make(map[string]*labeledReturn)
+	mustGet := func(label string) *labeledReturn {
+		ret, ok := returns[label]
+		if !ok {
+			ret = new(labeledReturn)
+			returns[label] = ret
+		}
+		return ret
+	}
+
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
-		p := c.Parent() // parent node
 		switch n := c.Node().(type) {
 		case *ast.LabeledStmt:
 			switch s := n.Stmt.(type) {
 			case *ast.ReturnStmt:
-
-				// Only try to "inline" this return
-				// if it's a return of "simple" values,
-				// otherwise this can increase complexity.
-				if isSimpleReturn(s) {
-					returns[n.Label.Name] = s
-
-					// Only if this labeled return DEFINITIVELY
-					// cannot be fallen-through-to, do we remove
-					// it. Otherwise drop label and keep return.
-					if p := getPreviousInBlock(p, n); //
-					cannotFallthrough(p) {
-						c.Delete()
-					} else {
-						c.Replace(s)
-					}
-				}
-
+				// Gather information on
+				// explicit labeled returns.
+				ret := mustGet(n.Label.Name)
+				ret.Simple = isSimpleReturn(s)
+				prev := getPreviousInBlock(c.Parent(), n)
+				ret.NoFall = cannotFallthrough(prev)
+				ret.Stmt = s
 			case *ast.EmptyStmt:
-				// If this is the last stmt in the function
-				// body and it's empty, all gotos can be
-				// replaced with a zero parameter return.
-				//
-				// We don't need to check for fallthroughs as unless this
-				// is invalid AST, reaching the end of the function block
-				// will be semantically equivalent to an empty return.
-				if fn.Body.List[len(fn.Body.List)-1] == n {
-					returns[n.Label.Name] = &ast.ReturnStmt{}
-					c.Delete()
+				// Also add a "deletion" marker for implicit
+				// labeled returns, i.e. goto: function end.
+				if n == fn.Body.List[len(fn.Body.List)-1] {
+					ret := mustGet(n.Label.Name)
+					ret.Simple = true
+					ret.NoFall = true
+					ret.Stmt = &ast.ReturnStmt{}
 				}
+			}
+		case *ast.BranchStmt:
+			if n.Tok == token.GOTO {
+				// Count uses of all labels.
+				ret := mustGet(n.Label.Name)
+				ret.Uses++
 			}
 		}
 		return true
 	})
 
-	// Second walk to replace matching labels with return.
+	// Filter out any without a return set,
+	// i.e. labeled non-single-return blocks.
+	for label, ret := range returns {
+		if ret.Stmt == nil {
+			delete(returns, label)
+		}
+	}
+
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		switch n := c.Node().(type) {
+		case *ast.LabeledStmt:
+			switch s := n.Stmt.(type) {
+			case *ast.ReturnStmt:
+				switch ret := mustGet(n.Label.Name); {
+				// All returns that can't be fallen-into and are
+				// either simple enough to not increase function
+				// complexity if inlined, or are complex but only
+				// used once, we remove and inline in the function.
+				case ret.NoFall && (ret.Uses <= 1 || ret.Simple):
+					c.Delete()
+
+				// i.e. simple but can't definitively say that it
+				// can't be fallen-through-to. we leave the return
+				// in place but drop the label.
+				case ret.Simple:
+					c.Replace(s)
+				}
+			case *ast.EmptyStmt:
+				// It's safe to remove all empty statement
+				// labels we gathered, these will only be
+				// implicit returns at end of function body.
+				if _, ok := returns[n.Label.Name]; ok {
+					c.Delete()
+				}
+			}
 		case *ast.BranchStmt:
 			if n.Tok == token.GOTO {
-				ret, ok := returns[n.Label.Name]
-				if ok {
-					c.Replace(ret)
+				// Replace all "goto ${label}" instances of those
+				// labels replaced / deleted above, with just the
+				// return statement originally contained at label.
+				if ret, ok := returns[n.Label.Name]; //
+				ok && (ret.Simple || ret.NoFall && ret.Uses <= 1) {
+					c.Replace(ret.Stmt)
 				}
 			}
 		}
@@ -350,16 +390,69 @@ func cannotFallthrough(n ast.Node) bool {
 	switch n := n.(type) {
 	case *ast.LabeledStmt:
 		return cannotFallthrough(n.Stmt)
+
 	case *ast.ReturnStmt:
 		return true
+
 	case *ast.BranchStmt:
-		return n.Tok != token.BREAK
+		switch n.Tok {
+		// Anything other than GOTO / CONTINUE
+		// alters the control flow in such a
+		// way we can't guarantee it won't fall.
+		case token.GOTO, token.CONTINUE:
+			return true
+		default:
+			return false
+		}
+
 	case *ast.BlockStmt:
+		// Empty block always
+		// falls to successor.
 		if len(n.List) == 0 {
 			return false
 		}
+
+		// Check if last statement
+		// in block falls through.
 		last := n.List[len(n.List)-1]
 		return cannotFallthrough(last)
+
+	case *ast.SwitchStmt:
+		var hasDefault bool
+
+		// Check through all clauses.
+		for _, n := range n.Body.List {
+			cc, _ := n.(*ast.CaseClause)
+
+			// Empty case always
+			// falls to successor.
+			if len(cc.List) == 0 {
+				return false
+			}
+
+			// Check if any statements
+			// in block can break-out.
+			//
+			// TODO?: this is quite limited
+			// in its heuristic abilities here
+			// without handling breaks separately.
+			for _, n := range cc.List {
+				if !cannotFallthrough(n) {
+					return false
+				}
+			}
+
+			if !hasDefault {
+				// Check if case is default stmt.
+				hasDefault = (len(cc.List) == 0)
+			}
+		}
+
+		// None of cases fallthrough
+		// only definitely doesn't if
+		// there's a default case.
+		return hasDefault
+
 	default:
 		return false
 	}
@@ -385,6 +478,11 @@ func isSimpleValue(n ast.Expr) bool {
 		return true
 	case *ast.BasicLit:
 		return true
+	case *ast.UnaryExpr:
+		return isSimpleValue(n.X)
+	case *ast.BinaryExpr:
+		return isSimpleValue(n.X) &&
+			isSimpleValue(n.Y)
 	case *ast.CallExpr:
 		if len(n.Args) != 1 {
 			return false

--- a/util/opt.go
+++ b/util/opt.go
@@ -422,20 +422,14 @@ func cannotFallthrough(n ast.Node) bool {
 
 			// Empty case always
 			// falls to successor.
-			if len(cc.List) == 0 {
+			if len(cc.Body) == 0 {
 				return false
 			}
 
 			// Check if any statements
 			// in block can break-out.
-			//
-			// TODO?: this is quite limited
-			// in its heuristic abilities here
-			// without handling breaks separately.
-			for _, n := range cc.List {
-				if !cannotFallthrough(n) {
-					return false
-				}
+			if !cannotBreak(cc.Body) {
+				return false
 			}
 
 			if !hasDefault {
@@ -449,9 +443,63 @@ func cannotFallthrough(n ast.Node) bool {
 		// there's a default case.
 		return hasDefault
 
+	case *ast.ForStmt:
+		// Any for loops with a
+		// cond can fallthrough.
+		if n.Cond != nil {
+			return false
+		}
+
+		// Otherwise, check for a BREAK.
+		return cannotBreak(n.Body.List)
+
+	case *ast.IfStmt:
+		// Any if without an
+		// else can fallthrough.
+		if n.Else == nil {
+			return false
+		}
+
+		// Otherwise check if either body can.
+		return cannotFallthrough(n.Body) &&
+			cannotFallthrough(n.Else)
+
 	default:
 		return false
 	}
+}
+
+// cannotBreak returns whether the list of expressions / statements passed
+// DEFINITIVELY DO NOT break out from that list. the default value is false.
+func cannotBreak[T any](list []T) bool {
+	if len(list) == 0 {
+		return false
+	}
+	for _, e := range list {
+		switch e := any(e).(type) {
+		// Some simple types
+		// we know don't break.
+		case *ast.CallExpr:
+		case *ast.BinaryExpr:
+		case *ast.AssignStmt:
+		case *ast.ReturnStmt:
+
+		// Handle specific
+		// flow branch types.
+		case *ast.BranchStmt:
+			switch e.Tok {
+			case token.BREAK,
+				token.FALLTHROUGH:
+				return false
+			}
+
+		// All else treat as a
+		// break from case / loop.
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // isSimpleReturn applies isSimpleValue() to each of the return's

--- a/util/opt.go
+++ b/util/opt.go
@@ -303,6 +303,7 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 				prev := getPreviousInBlock(c.Parent(), n)
 				ret.NoFall = cannotFallthrough(prev)
 				ret.Stmt = s
+
 			case *ast.EmptyStmt:
 				// Also add a "deletion" marker for implicit
 				// labeled returns, i.e. goto: function end.
@@ -396,11 +397,21 @@ func cannotFallthrough(n ast.Node) bool {
 	case *ast.LabeledStmt:
 		return cannotFallthrough(n.Stmt)
 
+	case *ast.ExprStmt:
+		return cannotFallthrough(n.X)
+
 	case *ast.ReturnStmt:
 		return true
 
 	case *ast.BranchStmt:
+		// It shouldn't be possible
+		// for anything other than
+		// a GOTO to be passed here.
 		return n.Tok == token.GOTO
+
+	case *ast.CallExpr:
+		id, ok := n.Fun.(*ast.Ident)
+		return ok && id.Name == "panic"
 
 	case *ast.BlockStmt:
 		// Empty block always
@@ -439,7 +450,7 @@ func cannotFallthrough(n ast.Node) bool {
 			}
 		}
 
-		// None of cases fallthrough
+		// Case WITHOUT fallthrough
 		// only definitely doesn't if
 		// there's a default case.
 		return hasDefault
@@ -473,9 +484,6 @@ func cannotFallthrough(n ast.Node) bool {
 // cannotBreak returns whether the list of expressions / statements passed
 // DEFINITIVELY DO NOT break out from that list. the default value is false.
 func cannotBreak[T any](list []T) bool {
-	if len(list) == 0 {
-		return false
-	}
 	for _, e := range list {
 		switch e := any(e).(type) {
 		// Some simple types
@@ -485,6 +493,54 @@ func cannotBreak[T any](list []T) bool {
 		case *ast.BinaryExpr:
 		case *ast.AssignStmt:
 		case *ast.ReturnStmt:
+
+		case *ast.ExprStmt:
+			// Check wrapped expression.
+			if !cannotBreak([]any{e.X}) {
+				return false
+			}
+
+		case *ast.ForStmt:
+			// Check whether for loop contains any breaks.
+			if e.Body != nil && !cannotBreak(e.Body.List) {
+				return false
+			}
+
+		case *ast.IfStmt:
+			// Check if main IF can break.
+			if !cannotBreak(e.Body.List) {
+				return false
+			}
+
+			// Check if ELSE can break.
+			switch e := e.Else.(type) {
+			case nil:
+			case *ast.BlockStmt:
+				if !cannotBreak(e.List) {
+					return false
+				}
+			default:
+				if !cannotBreak([]ast.Stmt{e}) {
+					return false
+				}
+			}
+
+		case *ast.SwitchStmt:
+			// Check through all clauses.
+			for _, n := range e.Body.List {
+				cc, _ := n.(*ast.CaseClause)
+
+				// Empty doesn't break.
+				if len(cc.Body) == 0 {
+					return false
+				}
+
+				// Check if any statements
+				// in block can break-out.
+				if !cannotBreak(cc.Body) {
+					return false
+				}
+			}
 
 		// Handle specific
 		// flow branch types.

--- a/util/opt.go
+++ b/util/opt.go
@@ -259,27 +259,49 @@ func RemoveParens(n ast.Node) {
 }
 
 // SimplifyGotos replaces all instances of "goto ${label}" with the contents
-// of its code block specifically where it only contains a return statement.
-func SimplifyGotos(root ast.Node) {
+// of its code block specifically where it only contains a return statement,
+// or an empty statement and is the last in the function block.
+func SimplifyGotos(fn *ast.FuncDecl) {
 	returns := make(map[string]*ast.ReturnStmt)
 
 	// First walk to find labelled statements that only contain
 	// a return, collecting the return and deleting the label.
-	astutil.Apply(root, nil, func(c *astutil.Cursor) bool {
+	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		switch n := c.Node().(type) {
 		case *ast.LabeledStmt:
 			switch s := n.Stmt.(type) {
 			case *ast.ReturnStmt:
 				returns[n.Label.Name] = s
-				c.Delete()
+
+				// If this isn't the last stmt in the function
+				// body, labeled return can safely be deleted.
+				if fn.Body.List[len(fn.Body.List)-1] != n {
+					c.Delete()
+					break
+				}
+
+				// Else just drop label
+				// and inline the return.
+				c.Replace(s)
+
+			case *ast.EmptyStmt:
+				// If this is the last stmt in the function
+				// body and it's empty, all gotos can be
+				// replaced with a zero parameter return.
+				if fn.Body.List[len(fn.Body.List)-1] == n {
+					returns[n.Label.Name] = &ast.ReturnStmt{}
+					c.Delete()
+				}
 			}
 		}
 		return true
 	})
 
 	// Second walk to replace all "goto ${label}" with return.
-	astutil.Apply(root, nil, func(c *astutil.Cursor) bool {
+	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		switch n := c.Node().(type) {
+		case *ast.LabeledStmt:
+
 		case *ast.BranchStmt:
 			if n.Tok == token.GOTO {
 				ret, ok := returns[n.Label.Name]

--- a/util/opt.go
+++ b/util/opt.go
@@ -395,15 +395,11 @@ func cannotFallthrough(n ast.Node) bool {
 		return true
 
 	case *ast.BranchStmt:
-		switch n.Tok {
-		// Anything other than GOTO / CONTINUE
-		// alters the control flow in such a
-		// way we can't guarantee it won't fall.
-		case token.GOTO, token.CONTINUE:
-			return true
-		default:
-			return false
-		}
+		// Anything other than GOTO isn't
+		// expected to be passed to this
+		// function, or needs more granular
+		// handling in a cannotBreak() func.
+		return n.Tok == token.GOTO
 
 	case *ast.BlockStmt:
 		// Empty block always

--- a/util/opt.go
+++ b/util/opt.go
@@ -279,11 +279,9 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 			switch s := n.Stmt.(type) {
 			case *ast.ReturnStmt:
 
-				// Only try to "inline" this
-				// return if it's a return of
-				// "simple" values, otherwise
-				// this can increase function
-				// hairiness to the Go compiler.
+				// Only try to "inline" this return
+				// if it's a return of "simple" values,
+				// otherwise this can increase complexity.
 				if isSimpleReturn(s) {
 					returns[n.Label.Name] = s
 
@@ -346,12 +344,10 @@ func getPreviousInBlock(p ast.Node, n ast.Stmt) ast.Node {
 	}
 }
 
-// cannotFallthrough returns whether the given node 'n' will definitively
+// cannotFallthrough returns whether the given node 'n' will DEFINITIVELY
 // NOT fallthrough to the stmt succeeding it. default return value is false.
 func cannotFallthrough(n ast.Node) bool {
 	switch n := n.(type) {
-	case nil:
-		return true
 	case *ast.LabeledStmt:
 		return cannotFallthrough(n.Stmt)
 	case *ast.ReturnStmt:
@@ -390,13 +386,19 @@ func isSimpleValue(n ast.Expr) bool {
 	case *ast.BasicLit:
 		return true
 	case *ast.CallExpr:
-		if len(n.Args) == 1 {
-			if id, ok := n.Fun.(*ast.Ident); ok &&
-				(strings.HasPrefix(id.Name, "int") ||
-					strings.HasPrefix(id.Name, "uint") ||
-					strings.HasPrefix(id.Name, "float")) {
-				return isSimpleValue(n.Args[0])
-			}
+		if len(n.Args) != 1 {
+			return false
+		}
+		id, ok := n.Fun.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		switch id.Name {
+		case "int", "int8", "int16", "int32", "int64", // signed integer types
+			"uint", "uint8", "uint16", "uint32", "uint64", // unsigned integer types
+			"float32", "float64", // float types
+			"i32", "i64", "f32", "f64": // anti-const-folding helpers (see helpers/helpers.go)
+			return isSimpleValue(n.Args[0])
 		}
 	}
 	return false

--- a/util/opt.go
+++ b/util/opt.go
@@ -268,23 +268,19 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 	// First walk to find labelled statements that only contain
 	// a return, collecting the return and deleting the label.
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
+		p := c.Parent() // parent node
 		switch n := c.Node().(type) {
 		case *ast.LabeledStmt:
 			switch s := n.Stmt.(type) {
 			case *ast.ReturnStmt:
 				if isSimpleReturn(s) {
 					returns[n.Label.Name] = s
-
-					// If this isn't the last stmt in the function
-					// body, labeled return can safely be deleted.
-					if fn.Body.List[len(fn.Body.List)-1] != n {
+					if p := getPreviousInBlock(p, n); //
+					cannotFallthrough(p) {
 						c.Delete()
-						break
+					} else {
+						c.Replace(s)
 					}
-
-					// Else just drop label
-					// and inline the return.
-					c.Replace(s)
 				}
 
 			case *ast.EmptyStmt:
@@ -313,6 +309,45 @@ func SimplifyGotos(fn *ast.FuncDecl) {
 		}
 		return true
 	})
+}
+
+// getPreviousInBlock attempts to return the previous node to current 'n' in the given
+// parent block 'p', i.e. searching for the previous node to 'n' in parent block's stmt list.
+func getPreviousInBlock(p ast.Node, n ast.Stmt) ast.Node {
+	switch p := p.(type) {
+	case *ast.BlockStmt:
+		i := slices.Index(p.List, n)
+		if i > 0 {
+			return p.List[i-1]
+		} else {
+			return nil
+		}
+	default:
+		return nil
+	}
+}
+
+// cannotFallthrough returns whether the given node 'n' will definitively
+// NOT fallthrough to the stmt succeeding it. default return value is false.
+func cannotFallthrough(n ast.Node) bool {
+	switch n := n.(type) {
+	case nil:
+		return true
+	case *ast.LabeledStmt:
+		return cannotFallthrough(n.Stmt)
+	case *ast.ReturnStmt:
+		return true
+	case *ast.BranchStmt:
+		return n.Tok != token.BREAK
+	case *ast.BlockStmt:
+		if len(n.List) == 0 {
+			return false
+		}
+		last := n.List[len(n.List)-1]
+		return cannotFallthrough(last)
+	default:
+		return false
+	}
 }
 
 // isSimpleReturn applies isSimpleValue() to each of the return's


### PR DESCRIPTION
adds an optimization pass to replaces all instances of "goto ${label}" with a return statement, specifically where labeled block matches an empty labeled statement at the end of function body OR a labeled statement consisting of only a "simple" return.

running this on go-sqlite3-wasm results in:
```
 sqlite3.go | 3042 +++++++++++++++++++++++++-----------------------------------
 1 file changed, 1255 insertions(+), 1787 deletions(-)
```
