### PR TITLE
Add -pkg flag to override the generated package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	output  = flag.String("o", "", "output file (default stdout)")
-	pkgName = flag.String("pkg", "", "package name for the generated file (default module name, or wasm2go)")
-	tags    = flag.String("tags", "", "go:build tags to include in the generated file")
+	output = flag.String("o", "", "output file (default stdout)")
+	pkg    = flag.String("pkg", "", "package name (default module name, or wasm2go)")
+	tags   = flag.String("tags", "", "go:build tags to include in the generated file")
 
 	embed  = flag.Bool("embed", false, "go:embed data sections from a .dat file")
 	nanbox = flag.Bool("nanbox", false, "attempt to canonicalize NaNs")

--- a/main.go
+++ b/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	output = flag.String("o", "", "output file (default stdout)")
-	tags   = flag.String("tags", "", "go:build tags to include in the generated file")
+	output  = flag.String("o", "", "output file (default stdout)")
+	pkgName = flag.String("pkg", "", "package name for the generated file (default module name, or wasm2go)")
+	tags    = flag.String("tags", "", "go:build tags to include in the generated file")
 
 	embed  = flag.Bool("embed", false, "go:embed data sections from a .dat file")
 	nanbox = flag.Bool("nanbox", false, "attempt to canonicalize NaNs")

--- a/translate.go
+++ b/translate.go
@@ -142,10 +142,10 @@ func translate(r io.Reader, w io.Writer) error {
 		t.createNewFunc()},
 		t.out.Decls...)
 
-	// Fill in missing names.
-	if *pkgName != "" {
-		t.out.Name = newID(*pkgName)
+	if *pkg != "" {
+		t.out.Name = newID(*pkg)
 	}
+	// Fill in missing names.
 	if t.out.Name == nil {
 		t.out.Name = newID("wasm2go")
 	}

--- a/translate.go
+++ b/translate.go
@@ -143,6 +143,9 @@ func translate(r io.Reader, w io.Writer) error {
 		t.out.Decls...)
 
 	// Fill in missing names.
+	if *pkgName != "" {
+		t.out.Name = newID(*pkgName)
+	}
 	if t.out.Name == nil {
 		t.out.Name = newID("wasm2go")
 	}


### PR DESCRIPTION
Tools like wasm-opt may not pass the module name through.