### PR TITLE
Track types on codegen stack

### DIFF
--- a/code.go
+++ b/code.go
@@ -43,6 +43,9 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 
 	// Declare local variables.
 	// Parameters are predeclared locals.
+	for _, b := range []byte(fn.typ.params) {
+		fn.localTypes = append(fn.localTypes, wasmType(b).ident().Name)
+	}
 	vars := make([]ast.Expr, 0, numVars)
 	numLocals := len(fn.typ.params)
 	for range numVars {
@@ -59,6 +62,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 		for i := range int(n) {
 			ids[i] = localVar(numLocals)
 			vars = append(vars, ids[i])
+			fn.localTypes = append(fn.localTypes, wasmType(typ).ident().Name)
 			numLocals++
 		}
 		body.List = append(body.List, &ast.DeclStmt{
@@ -165,8 +169,8 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 				}
 				// The variables only change at block re-entry (loop).
 				childBlk.params = lhs
-				for _, p := range lhs {
-					fn.pushConst(p)
+				for i, p := range lhs {
+					fn.pushConst(p, wasmType(bt.params[i]).ident().Name)
 				}
 				fn.emit(&ast.AssignStmt{
 					Tok: token.DEFINE,
@@ -214,8 +218,8 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			}
 			// Push the if's arguments again for the else branch.
 			// These were constant.
-			for _, p := range blk.params {
-				fn.pushConst(p)
+			for i, p := range blk.params {
+				fn.pushConst(p, wasmType(blk.typ.params[i]).ident().Name)
 			}
 			// Create a new block at the same level,
 			// make it the else branch.
@@ -266,8 +270,8 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			}
 			// Push the results again, for the parent block.
 			// The variables never change again.
-			for _, r := range blk.results {
-				fn.pushConst(r)
+			for i, r := range blk.results {
+				fn.pushConst(r, wasmType(blk.typ.results[i]).ident().Name)
 			}
 
 			fn.blocks.pop()
@@ -429,7 +433,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 				case 0:
 					fn.emit(&ast.ExprStmt{X: call})
 				case 1:
-					fn.push(call)
+					fn.push(call, wasmType(typ.results[0]).ident().Name)
 				default:
 					lhs := make([]ast.Expr, n)
 					for i := range lhs {
@@ -439,8 +443,8 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 						Lhs: lhs,
 						Tok: token.DEFINE,
 						Rhs: []ast.Expr{call}})
-					for _, r := range lhs {
-						fn.pushConst(r)
+					for i, r := range lhs {
+						fn.pushConst(r, wasmType(typ.results[i]).ident().Name)
 					}
 				}
 			}
@@ -467,6 +471,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 
 		case 0x1b: // select
 			cond := fn.popCond()
+			t := fn.topType()
 			tmp := fn.newTempVar()
 			fn.emit(&ast.AssignStmt{
 				Tok: token.DEFINE,
@@ -481,7 +486,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 						Rhs: []ast.Expr{fn.pop()}}}},
 			})
 			// This variable never changes again.
-			fn.pushConst(tmp)
+			fn.pushConst(tmp, t)
 
 		case 0x1c: // select (typed)
 			n, err := readLEB128(t.in)
@@ -504,7 +509,9 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			}
 
 			vf := make([]ast.Expr, n)
+			vft := make([]string, n)
 			for i := int(n) - 1; i >= 0; i-- {
+				vft[i] = fn.topType()
 				vf[i] = fn.pop()
 			}
 
@@ -531,8 +538,8 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 						Rhs: vt}}}})
 
 			// These variables never change again.
-			for _, t := range tmp {
-				fn.pushConst(t)
+			for i, t := range tmp {
+				fn.pushConst(t, vft[i])
 			}
 
 		case 0x20: // local.get
@@ -540,7 +547,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			if err != nil {
 				return err
 			}
-			fn.pushPure(localVar(i)) // Pure because assigning locals flushes.
+			fn.pushPure(localVar(i), fn.localTypes[i]) // Pure because assigning locals flushes.
 
 		case 0x21: // local.set
 			i, err := readLEB128(t.in)
@@ -561,14 +568,14 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 				Lhs: []ast.Expr{localVar(i)},
 				Rhs: []ast.Expr{fn.pop()},
 				Tok: token.ASSIGN})
-			fn.pushPure(localVar(i)) // Pure because assigning locals flushes.
+			fn.pushPure(localVar(i), fn.localTypes[i]) // Pure because assigning locals flushes.
 
 		case 0x23: // global.get
-			e, mut, err := t.globalGet()
+			e, typ, mut, err := t.globalGet()
 			if err != nil {
 				return err
 			}
-			fn.pushPureIf(!mut, e)
+			fn.pushPureIf(!mut, e, typ)
 
 		case 0x24: // global.set
 			i, err := readLEB128(t.in)
@@ -594,7 +601,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			if t.tables[i].imported {
 				tab = &ast.StarExpr{X: tab}
 			}
-			fn.push(&ast.IndexExpr{X: tab, Index: fn.pop()})
+			fn.push(&ast.IndexExpr{X: tab, Index: fn.pop()}, "any")
 
 		case 0x26: // table.set
 			i, err := readLEB128(t.in)
@@ -623,13 +630,13 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			idx := fn.load8(offset)
 			switch opcode {
 			case 0x2c: // i32.load8_s
-				fn.push(convert(idx, "int8", "int32"))
+				fn.pushConvert(idx, "int8", "int32")
 			case 0x2d: // i32.load8_u
-				fn.push(convert(idx, "int32"))
+				fn.pushConvert(idx, "int32")
 			case 0x30: // i64.load8_s
-				fn.push(convert(idx, "int8", "int64"))
+				fn.pushConvert(idx, "int8", "int64")
 			case 0x31: // i64.load8_u
-				fn.push(convert(idx, "int64"))
+				fn.pushConvert(idx, "int64")
 			}
 
 		case 0x28, 0x29, 0x2a, 0x2b, 0x2e, 0x2f, 0x32, 0x33, 0x34, 0x35: // load
@@ -644,25 +651,25 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 
 			switch opcode {
 			case 0x28: // i32.load
-				fn.push(fn.load("int32", offset))
+				fn.push(fn.load("int32", offset), "int32")
 			case 0x29: // i64.load
-				fn.push(fn.load("int64", offset))
+				fn.push(fn.load("int64", offset), "int64")
 			case 0x2a: // f32.load
-				fn.push(fn.load("float32", offset))
+				fn.push(fn.load("float32", offset), "float32")
 			case 0x2b: // f64.load
-				fn.push(fn.load("float64", offset))
+				fn.push(fn.load("float64", offset), "float64")
 			case 0x2e: // i32.load16_s
-				fn.push(convert(fn.load("int16", offset), "int32"))
+				fn.pushConvert(fn.load("int16", offset), "int32")
 			case 0x2f: // i32.load16_u
-				fn.push(convert(fn.load("uint16", offset), "int32"))
+				fn.pushConvert(fn.load("uint16", offset), "int32")
 			case 0x32: // i64.load16_s
-				fn.push(convert(fn.load("int16", offset), "int64"))
+				fn.pushConvert(fn.load("int16", offset), "int64")
 			case 0x33: // i64.load16_u
-				fn.push(convert(fn.load("uint16", offset), "int64"))
+				fn.pushConvert(fn.load("uint16", offset), "int64")
 			case 0x34: // i64.load32_s
-				fn.push(convert(fn.load("int32", offset), "int64"))
+				fn.pushConvert(fn.load("int32", offset), "int64")
 			case 0x35: // i64.load32_u
-				fn.push(convert(fn.load("uint32", offset), "int64"))
+				fn.pushConvert(fn.load("uint32", offset), "int64")
 			}
 
 		case 0x3a, 0x3c: // store8
@@ -716,35 +723,35 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			}
 			switch {
 			case !t.memory.shared:
-				fn.push(convert(
+				fn.pushConvert(
 					&ast.BinaryExpr{
 						X: &ast.CallExpr{
 							Fun:  newID("len"),
 							Args: []ast.Expr{t.memory.selector}},
 						Op: token.SHR,
 						Y:  literal16,
-					}, t.memory.stype()))
+					}, t.memory.stype())
 
 			case t.memory.imported:
-				fn.push(convert(&ast.CallExpr{
+				fn.pushConvert(&ast.CallExpr{
 					Fun: &ast.SelectorExpr{
 						X:   &ast.SelectorExpr{X: newID("m"), Sel: newID("memImp")},
 						Sel: newID("Grow")},
 					Args: []ast.Expr{
 						literal0,
 						&ast.SelectorExpr{X: newID("m"), Sel: newID("maxMem")}}},
-					t.memory.stype()))
+					t.memory.stype())
 
 			default:
 				needsUnsafe("shared memory")
 				fn.helpers.add("atomic_memory_grow")
-				fn.push(convert(&ast.CallExpr{
+				fn.pushConvert(&ast.CallExpr{
 					Fun: newID("atomic_memory_grow"),
 					Args: []ast.Expr{
 						&ast.UnaryExpr{Op: token.AND, X: t.memory.selector},
 						literal0,
 						&ast.SelectorExpr{X: newID("m"), Sel: newID("maxMem")}}},
-					t.memory.stype()))
+					t.memory.stype())
 			}
 
 		case 0x40: // memory.grow
@@ -753,14 +760,14 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 				return err
 			}
 			if fn.memory.imported {
-				fn.push(convert(&ast.CallExpr{
+				fn.pushConvert(&ast.CallExpr{
 					Fun: &ast.SelectorExpr{
 						X:   &ast.SelectorExpr{X: newID("m"), Sel: newID("memImp")},
 						Sel: newID("Grow")},
 					Args: []ast.Expr{
 						convert(fn.pop(), "int64"),
 						&ast.SelectorExpr{X: newID("m"), Sel: newID("maxMem")}}},
-					t.memory.stype()))
+					t.memory.stype())
 			} else {
 				name := "memory_grow"
 				if t.memory.shared {
@@ -768,13 +775,13 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 					needsUnsafe("shared memory")
 				}
 				fn.helpers.add(name)
-				fn.push(convert(&ast.CallExpr{
+				fn.pushConvert(&ast.CallExpr{
 					Fun: newID(name),
 					Args: []ast.Expr{
 						&ast.UnaryExpr{Op: token.AND, X: t.memory.selector},
 						convert(fn.pop(), "int64"),
 						&ast.SelectorExpr{X: newID("m"), Sel: newID("maxMem")}}},
-					t.memory.stype()))
+					t.memory.stype())
 			}
 
 		case 0x41: // i32.const
@@ -782,28 +789,28 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			if err != nil {
 				return err
 			}
-			fn.pushConst(e)
+			fn.pushConst(e, "int32")
 
 		case 0x42: // i64.const
 			e, err := t.constI64()
 			if err != nil {
 				return err
 			}
-			fn.pushConst(e)
+			fn.pushConst(e, "int64")
 
 		case 0x43: // f32.const
 			e, err := t.constF32()
 			if err != nil {
 				return err
 			}
-			fn.pushConst(e)
+			fn.pushConst(e, "float32")
 
 		case 0x44: // f64.const
 			e, err := t.constF64()
 			if err != nil {
 				return err
 			}
-			fn.pushConst(e)
+			fn.pushConst(e, "float64")
 
 		case 0x45: // i32.eqz
 			fn.eqzOp()
@@ -954,7 +961,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 		case 0x8b: // f32.abs
 			fn.uniHelper("f32_abs")
 		case 0x8c: // f32.neg
-			fn.pushPure(&ast.UnaryExpr{Op: token.SUB, X: fn.pop()})
+			fn.pushPure(&ast.UnaryExpr{Op: token.SUB, X: fn.pop()}, "float32")
 		case 0x8d: // f32.ceil
 			fn.uniMath32("Ceil")
 		case 0x8e: // f32.floor
@@ -991,7 +998,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 		case 0x99: // f64.abs
 			fn.uniMath64("Abs")
 		case 0x9a: // f64.neg
-			fn.pushPure(&ast.UnaryExpr{Op: token.SUB, X: fn.pop()})
+			fn.pushPure(&ast.UnaryExpr{Op: token.SUB, X: fn.pop()}, "float64")
 		case 0x9b: // f64.ceil
 			fn.uniMath64("Ceil")
 		case 0x9c: // f64.floor
@@ -1098,7 +1105,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 			if err != nil {
 				return err
 			}
-			fn.pushConst(newID("nil"))
+			fn.pushConst(newID("nil"), "any")
 		case 0xd1: // ref.is_null
 			fn.pushCond(&ast.BinaryExpr{
 				X:  fn.pop(),
@@ -1110,7 +1117,7 @@ func (t *translator) readCodeForFunction(fn *funcCompiler) error {
 				return err
 			}
 			// Push to materialize the reference.
-			fn.push(t.functions[index].call)
+			fn.push(t.functions[index].call, "any")
 
 		case 0xfb: // GC
 			code, err := readLEB128(t.in)

--- a/code_atomic.go
+++ b/code_atomic.go
@@ -32,26 +32,26 @@ func (t *translator) readOpcodeAtomic(fn *funcCompiler) error {
 
 	switch code {
 	case 0x00: // memory.atomic.notify
-		fn.push(fn.atomicNotify("atomic_notify", offset))
+		fn.push(fn.atomicNotify("atomic_notify", offset), "int32")
 	case 0x01: // memory.atomic.wait32
-		fn.push(fn.atomicWait("atomic_wait32", offset))
+		fn.push(fn.atomicWait("atomic_wait32", offset), "int32")
 	case 0x02: // memory.atomic.wait64
-		fn.push(fn.atomicWait("atomic_wait64", offset))
+		fn.push(fn.atomicWait("atomic_wait64", offset), "int32")
 
 	case 0x10: // i32.atomic.load
-		fn.push(fn.atomicLoad("int32", "atomic_load32", offset))
+		fn.push(fn.atomicLoad("int32", "atomic_load32", offset), "int32")
 	case 0x11: // i64.atomic.load
-		fn.push(fn.atomicLoad("int64", "atomic_load64", offset))
+		fn.push(fn.atomicLoad("int64", "atomic_load64", offset), "int64")
 	case 0x12: // i32.atomic.load8_u
-		fn.push(fn.atomicLoad("int32", "atomic_load8", offset))
+		fn.push(fn.atomicLoad("int32", "atomic_load8", offset), "int32")
 	case 0x13: // i32.atomic.load16_u
-		fn.push(fn.atomicLoad("int32", "atomic_load16", offset))
+		fn.push(fn.atomicLoad("int32", "atomic_load16", offset), "int32")
 	case 0x14: // i64.atomic.load8_u
-		fn.push(fn.atomicLoad("int64", "atomic_load8", offset))
+		fn.push(fn.atomicLoad("int64", "atomic_load8", offset), "int64")
 	case 0x15: // i64.atomic.load16_u
-		fn.push(fn.atomicLoad("int64", "atomic_load16", offset))
+		fn.push(fn.atomicLoad("int64", "atomic_load16", offset), "int64")
 	case 0x16: // i64.atomic.load32_u
-		fn.push(fn.atomicLoad("int64", "atomic_load32", offset))
+		fn.push(fn.atomicLoad("int64", "atomic_load32", offset), "int64")
 
 	case 0x17, 0x1d: // i32.atomic.store, i64.atomic.store32
 		fn.emit(fn.atomicStore("atomic_store32", offset))
@@ -63,109 +63,109 @@ func (t *translator) readOpcodeAtomic(fn *funcCompiler) error {
 		fn.emit(fn.atomicStore("atomic_store16", offset))
 
 	case 0x1e: // i32.atomic.rmw.add
-		fn.push(fn.atomicRmw("int32", "atomic_add32", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_add32", offset), "int32")
 	case 0x1f: // i64.atomic.rmw.add
-		fn.push(fn.atomicRmw("int64", "atomic_add64", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_add64", offset), "int64")
 	case 0x20: // i32.atomic.rmw8.add_u
-		fn.push(fn.atomicRmw("int32", "atomic_add8", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_add8", offset), "int32")
 	case 0x21: // i32.atomic.rmw16.add_u
-		fn.push(fn.atomicRmw("int32", "atomic_add16", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_add16", offset), "int32")
 	case 0x22: // i64.atomic.rmw8.add_u
-		fn.push(fn.atomicRmw("int64", "atomic_add8", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_add8", offset), "int64")
 	case 0x23: // i64.atomic.rmw16.add_u
-		fn.push(fn.atomicRmw("int64", "atomic_add16", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_add16", offset), "int64")
 	case 0x24: // i64.atomic.rmw32.add_u
-		fn.push(fn.atomicRmw("int64", "atomic_add32", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_add32", offset), "int64")
 
 	case 0x25: // i32.atomic.rmw.sub
-		fn.push(fn.atomicRmw("int32", "atomic_sub32", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_sub32", offset), "int32")
 	case 0x26: // i64.atomic.rmw.sub
-		fn.push(fn.atomicRmw("int64", "atomic_sub64", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_sub64", offset), "int64")
 	case 0x27: // i32.atomic.rmw8.sub_u
-		fn.push(fn.atomicRmw("int32", "atomic_sub8", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_sub8", offset), "int32")
 	case 0x28: // i32.atomic.rmw16.sub_u
-		fn.push(fn.atomicRmw("int32", "atomic_sub16", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_sub16", offset), "int32")
 	case 0x29: // i64.atomic.rmw8.sub_u
-		fn.push(fn.atomicRmw("int64", "atomic_sub8", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_sub8", offset), "int64")
 	case 0x2a: // i64.atomic.rmw16.sub_u
-		fn.push(fn.atomicRmw("int64", "atomic_sub16", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_sub16", offset), "int64")
 	case 0x2b: // i64.atomic.rmw32.sub_u
-		fn.push(fn.atomicRmw("int64", "atomic_sub32", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_sub32", offset), "int64")
 
 	case 0x2c: // i32.atomic.rmw.and
-		fn.push(fn.atomicRmw("int32", "atomic_and32", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_and32", offset), "int32")
 	case 0x2d: // i64.atomic.rmw.and
-		fn.push(fn.atomicRmw("int64", "atomic_and64", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_and64", offset), "int64")
 	case 0x2e: // i32.atomic.rmw8.and_u
-		fn.push(fn.atomicRmw("int32", "atomic_and8", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_and8", offset), "int32")
 	case 0x2f: // i32.atomic.rmw16.and_u
-		fn.push(fn.atomicRmw("int32", "atomic_and16", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_and16", offset), "int32")
 	case 0x30: // i64.atomic.rmw8.and_u
-		fn.push(fn.atomicRmw("int64", "atomic_and8", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_and8", offset), "int64")
 	case 0x31: // i64.atomic.rmw16.and_u
-		fn.push(fn.atomicRmw("int64", "atomic_and16", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_and16", offset), "int64")
 	case 0x32: // i64.atomic.rmw32.and_u
-		fn.push(fn.atomicRmw("int64", "atomic_and32", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_and32", offset), "int64")
 
 	case 0x33: // i32.atomic.rmw.or
-		fn.push(fn.atomicRmw("int32", "atomic_or32", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_or32", offset), "int32")
 	case 0x34: // i64.atomic.rmw.or
-		fn.push(fn.atomicRmw("int64", "atomic_or64", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_or64", offset), "int64")
 	case 0x35: // i32.atomic.rmw8.or_u
-		fn.push(fn.atomicRmw("int32", "atomic_or8", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_or8", offset), "int32")
 	case 0x36: // i32.atomic.rmw16.or_u
-		fn.push(fn.atomicRmw("int32", "atomic_or16", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_or16", offset), "int32")
 	case 0x37: // i64.atomic.rmw8.or_u
-		fn.push(fn.atomicRmw("int64", "atomic_or8", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_or8", offset), "int64")
 	case 0x38: // i64.atomic.rmw16.or_u
-		fn.push(fn.atomicRmw("int64", "atomic_or16", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_or16", offset), "int64")
 	case 0x39: // i64.atomic.rmw32.or_u
-		fn.push(fn.atomicRmw("int64", "atomic_or32", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_or32", offset), "int64")
 
 	case 0x3a: // i32.atomic.rmw.xor
-		fn.push(fn.atomicRmw("int32", "atomic_xor32", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_xor32", offset), "int32")
 	case 0x3b: // i64.atomic.rmw.xor
-		fn.push(fn.atomicRmw("int64", "atomic_xor64", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xor64", offset), "int64")
 	case 0x3c: // i32.atomic.rmw8.xor_u
-		fn.push(fn.atomicRmw("int32", "atomic_xor8", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_xor8", offset), "int32")
 	case 0x3d: // i32.atomic.rmw16.xor_u
-		fn.push(fn.atomicRmw("int32", "atomic_xor16", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_xor16", offset), "int32")
 	case 0x3e: // i64.atomic.rmw8.xor_u
-		fn.push(fn.atomicRmw("int64", "atomic_xor8", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xor8", offset), "int64")
 	case 0x3f: // i64.atomic.rmw16.xor_u
-		fn.push(fn.atomicRmw("int64", "atomic_xor16", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xor16", offset), "int64")
 	case 0x40: // i64.atomic.rmw32.xor_u
-		fn.push(fn.atomicRmw("int64", "atomic_xor32", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xor32", offset), "int64")
 
 	case 0x41: // i32.atomic.rmw.xchg
-		fn.push(fn.atomicRmw("int32", "atomic_xchg32", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_xchg32", offset), "int32")
 	case 0x42: // i64.atomic.rmw.xchg
-		fn.push(fn.atomicRmw("int64", "atomic_xchg64", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xchg64", offset), "int64")
 	case 0x43: // i32.atomic.rmw8.xchg_u
-		fn.push(fn.atomicRmw("int32", "atomic_xchg8", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_xchg8", offset), "int32")
 	case 0x44: // i32.atomic.rmw16.xchg_u
-		fn.push(fn.atomicRmw("int32", "atomic_xchg16", offset))
+		fn.push(fn.atomicRmw("int32", "atomic_xchg16", offset), "int32")
 	case 0x45: // i64.atomic.rmw8.xchg_u
-		fn.push(fn.atomicRmw("int64", "atomic_xchg8", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xchg8", offset), "int64")
 	case 0x46: // i64.atomic.rmw16.xchg_u
-		fn.push(fn.atomicRmw("int64", "atomic_xchg16", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xchg16", offset), "int64")
 	case 0x47: // i64.atomic.rmw32.xchg_u
-		fn.push(fn.atomicRmw("int64", "atomic_xchg32", offset))
+		fn.push(fn.atomicRmw("int64", "atomic_xchg32", offset), "int64")
 
 	case 0x48: // i32.atomic.rmw.cmpxchg
-		fn.push(fn.atomicCmpxchg("int32", "atomic_cmpxchg32", offset))
+		fn.push(fn.atomicCmpxchg("int32", "atomic_cmpxchg32", offset), "int32")
 	case 0x49: // i64.atomic.rmw.cmpxchg
-		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg64", offset))
+		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg64", offset), "int64")
 	case 0x4a: // i32.atomic.rmw8.cmpxchg_u
-		fn.push(fn.atomicCmpxchg("int32", "atomic_cmpxchg8", offset))
+		fn.push(fn.atomicCmpxchg("int32", "atomic_cmpxchg8", offset), "int32")
 	case 0x4b: // i32.atomic.rmw16.cmpxchg_u
-		fn.push(fn.atomicCmpxchg("int32", "atomic_cmpxchg16", offset))
+		fn.push(fn.atomicCmpxchg("int32", "atomic_cmpxchg16", offset), "int32")
 	case 0x4c: // i64.atomic.rmw8.cmpxchg_u
-		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg8", offset))
+		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg8", offset), "int64")
 	case 0x4d: // i64.atomic.rmw16.cmpxchg_u
-		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg16", offset))
+		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg16", offset), "int64")
 	case 0x4e: // i64.atomic.rmw32.cmpxchg_u
-		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg32", offset))
+		fn.push(fn.atomicCmpxchg("int64", "atomic_cmpxchg32", offset), "int64")
 
 	default:
 		return fmt.Errorf("unsupported opcode (atomic): 0xFE 0x%02X", code)

--- a/code_ext.go
+++ b/code_ext.go
@@ -187,7 +187,7 @@ func (t *translator) readOpcodeExtended(fn *funcCompiler) error {
 			Fun: newID("table_grow"),
 			Args: []ast.Expr{
 				tab, val, delta,
-				&ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(t.tables[idx].max)}}})
+				&ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(t.tables[idx].max)}}}, t.tables[idx].stype())
 
 	case 0x10: // table.size
 		idx, err := readLEB128(t.in)
@@ -198,10 +198,10 @@ func (t *translator) readOpcodeExtended(fn *funcCompiler) error {
 		if t.tables[idx].imported {
 			tab = &ast.StarExpr{X: tab}
 		}
-		fn.push(convert(&ast.CallExpr{
+		fn.pushConvert(&ast.CallExpr{
 			Fun:  newID("len"),
 			Args: []ast.Expr{tab},
-		}, t.tables[idx].stype()))
+		}, t.tables[idx].stype())
 
 	case 0x11: // table.fill
 		idx, err := readLEB128(t.in)
@@ -268,6 +268,6 @@ func (fn *funcCompiler) wideHelper(name string) {
 		Tok: token.DEFINE,
 		Lhs: []ast.Expr{lo, hi},
 		Rhs: []ast.Expr{&ast.CallExpr{Fun: newID(name), Args: args}}})
-	fn.pushConst(lo)
-	fn.pushConst(hi)
+	fn.pushConst(lo, "int64")
+	fn.pushConst(hi, "int64")
 }

--- a/const.go
+++ b/const.go
@@ -80,10 +80,10 @@ func (t *translator) constF64() (ast.Expr, error) {
 	}, nil
 }
 
-func (t *translator) globalGet() (ast.Expr, bool, error) {
+func (t *translator) globalGet() (ast.Expr, string, bool, error) {
 	v, err := readLEB128(t.in)
 	if err != nil {
-		return nil, false, err
+		return nil, "", false, err
 	}
 	global := t.globals[v]
 	var expr ast.Expr = &ast.SelectorExpr{
@@ -93,7 +93,7 @@ func (t *translator) globalGet() (ast.Expr, bool, error) {
 	if global.imported && global.mutable {
 		expr = &ast.StarExpr{X: expr}
 	}
-	return expr, global.mutable, nil
+	return expr, global.typ.ident().Name, global.mutable, nil
 }
 
 func formatInt(i int64) string {

--- a/fncompiler.go
+++ b/fncompiler.go
@@ -21,6 +21,8 @@ type funcCompiler struct {
 	labels int
 	temps  int
 
+	localTypes []string // Go type of each local (params first), for typing local.get
+
 	provided bool
 }
 
@@ -34,6 +36,7 @@ const (
 
 type stackEntry struct {
 	kind entryKind
+	typ  string // Go type of expr, if known ("" = unknown); enables long-form temps
 	expr ast.Expr
 }
 
@@ -189,17 +192,18 @@ func (fn *funcCompiler) store(typ string, offset uint64) ast.Stmt {
 			val}}}
 }
 
-// Pushes expr (a literal, constant or materialized temporary) to the value stack.
-func (fn *funcCompiler) pushConst(expr ast.Expr) {
-	fn.stack.append(stackEntry{expr: expr, kind: entryConst})
+// Pushes expr (a literal, constant or materialized temporary) of Go type typ
+// to the value stack.
+func (fn *funcCompiler) pushConst(expr ast.Expr, typ string) {
+	fn.stack.append(stackEntry{expr: expr, kind: entryConst, typ: typ})
 }
 
 // Pushes a pure expression (no observable side effects, including traps) to the value stack.
-func (fn *funcCompiler) pushPure(expr ast.Expr) {
+func (fn *funcCompiler) pushPure(expr ast.Expr, typ string) {
 	if fn.blocks.top().unreachable {
 		return
 	}
-	fn.stack.append(stackEntry{expr: expr, kind: entryExpr})
+	fn.stack.append(stackEntry{expr: expr, kind: entryExpr, typ: typ})
 	if *noopt {
 		fn.flush()
 	}
@@ -210,18 +214,18 @@ func (fn *funcCompiler) pushCond(cond ast.Expr) {
 	if fn.blocks.top().unreachable {
 		return
 	}
-	fn.stack.append(stackEntry{expr: cond, kind: entryCond})
+	fn.stack.append(stackEntry{expr: cond, kind: entryCond, typ: "int32"})
 	if *noopt {
 		fn.flush()
 	}
 }
 
 // Calls push or pushPure.
-func (fn *funcCompiler) pushPureIf(pure bool, expr ast.Expr) {
+func (fn *funcCompiler) pushPureIf(pure bool, expr ast.Expr, typ string) {
 	if pure {
-		fn.pushPure(expr)
+		fn.pushPure(expr, typ)
 	} else {
-		fn.push(expr)
+		fn.push(expr, typ)
 	}
 }
 
@@ -231,7 +235,7 @@ func (fn *funcCompiler) pushPureIf(pure bool, expr ast.Expr) {
 // This should be the default, since treating an expression as pure
 // could result in it being evaluated conditionally or
 // being reordered relative to other side-effectful operations.
-func (fn *funcCompiler) push(expr ast.Expr) {
+func (fn *funcCompiler) push(expr ast.Expr, typ string) {
 	if fn.blocks.top().unreachable {
 		return
 	}
@@ -241,7 +245,8 @@ func (fn *funcCompiler) push(expr ast.Expr) {
 		Tok: token.DEFINE,
 		Lhs: []ast.Expr{tmp},
 		Rhs: []ast.Expr{expr}})
-	fn.pushConst(tmp)
+	fn.pushConst(tmp, typ)
+}
 }
 
 // Drops a value from the value stack.
@@ -329,84 +334,79 @@ func (fn *funcCompiler) popAddr(offset uint64) (expr ast.Expr) {
 
 // Executes a type conversion, first to types[0], then to types[1] and so on.
 func (fn *funcCompiler) convert(types ...string) {
-	fn.pushPure(convert(fn.pop(), types...))
+	fn.pushPureConvert(fn.pop(), types...)
+}
+
+// pushConvert converts expr through types and pushes it; the final type is the
+// pushed value's type, so it is threaded to the stack. pushConvert is for
+// effectful/trapping conversions (e.g. loads); pushPureConvert for pure ones.
+func (fn *funcCompiler) pushConvert(expr ast.Expr, types ...string) {
+	fn.push(convert(expr, types...), types[len(types)-1])
+}
+
+func (fn *funcCompiler) pushPureConvert(expr ast.Expr, types ...string) {
+	fn.pushPure(convert(expr, types...), types[len(types)-1])
+}
+
+// topType returns the Go type of the top stack value -- the operand type, which
+// unary and binary wasm ops preserve and so reproduce as their result. The value
+// stack is moot in unreachable code (as in pop/popCond), so return "" there.
+func (fn *funcCompiler) topType() string {
+	if fn.blocks.top().unreachable {
+		return ""
+	}
+	return fn.stack.top().typ
 }
 
 // Executes a binary operator.
 func (fn *funcCompiler) binOp(op token.Token) {
-	fn.pushPureIf(op != token.QUO && op != token.REM,
-		&ast.BinaryExpr{
-			Y:  fn.pop(),
-			X:  fn.pop(),
-			Op: op})
+	t := fn.topType()
+	expr := &ast.BinaryExpr{Y: fn.pop(), X: fn.pop(), Op: op}
+	fn.pushPureIf(op != token.QUO && op != token.REM, expr, t)
 }
 
 // Executes a binary uint32 operator.
 // Requires casts to unsigned and back.
 func (fn *funcCompiler) binOpU32(op token.Token) {
-	fn.pushPureIf(op != token.QUO && op != token.REM,
-		convert(&ast.BinaryExpr{
-			Y:  convert(fn.pop(), "uint32"),
-			X:  convert(fn.pop(), "uint32"),
-			Op: op,
-		}, "int32"))
+	// QUO/REM can trap (divide by zero), so they are pushed eagerly.
+	expr := convert(&ast.BinaryExpr{Y: convert(fn.pop(), "uint32"), X: convert(fn.pop(), "uint32"), Op: op}, "int32")
+	fn.pushPureIf(op != token.QUO && op != token.REM, expr, "int32")
 }
 
 // Executes a binary uint64 operator.
 // Requires casts to unsigned and back.
 func (fn *funcCompiler) binOpU64(op token.Token) {
-	fn.pushPureIf(op != token.QUO && op != token.REM,
-		convert(&ast.BinaryExpr{
-			Y:  convert(fn.pop(), "uint64"),
-			X:  convert(fn.pop(), "uint64"),
-			Op: op,
-		}, "int64"))
+	expr := convert(&ast.BinaryExpr{Y: convert(fn.pop(), "uint64"), X: convert(fn.pop(), "uint64"), Op: op}, "int64")
+	fn.pushPureIf(op != token.QUO && op != token.REM, expr, "int64")
 }
 
 // Executes a binary float64 operator.
 // Requires casting the result,
 // to avoid operations being combined against the Wasm spec.
 func (fn *funcCompiler) binOpF64(op token.Token) {
-	fn.pushPure(
-		convert(&ast.BinaryExpr{
-			Y:  fn.pop(),
-			X:  fn.pop(),
-			Op: op,
-		}, "float64"))
+	fn.pushPureConvert(&ast.BinaryExpr{Y: fn.pop(), X: fn.pop(), Op: op}, "float64")
 }
 
 // Executes a binary float32 operator.
 // Requires casting the result,
 // to avoid operations being combined against the Wasm spec.
 func (fn *funcCompiler) binOpF32(op token.Token) {
-	fn.pushPure(
-		convert(&ast.BinaryExpr{
-			Y:  fn.pop(),
-			X:  fn.pop(),
-			Op: op,
-		}, "float32"))
+	fn.pushPureConvert(&ast.BinaryExpr{Y: fn.pop(), X: fn.pop(), Op: op}, "float32")
 }
 
 // Executes a unary bitwise call.
 func (fn *funcCompiler) bitOp(name string) {
 	bits := name[len(name)-2:]
-
-	fn.pushPure(
-		convert(&ast.CallExpr{
-			Fun: &ast.SelectorExpr{
-				X:   newID("bits"),
-				Sel: newID(name)},
-			Args: []ast.Expr{convert(fn.pop(), "uint"+bits)},
-		}, "int"+bits))
+	fn.pushPureConvert(&ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("bits"), Sel: newID(name)},
+		Args: []ast.Expr{convert(fn.pop(), "uint"+bits)}}, "int"+bits)
 }
 
 // Executes a unary float64 math call.
 func (fn *funcCompiler) uniMath64(name string) {
 	fn.pushPure(&ast.CallExpr{
-		Fun: &ast.SelectorExpr{
-			X:   newID("math"),
-			Sel: newID(name)},
-		Args: []ast.Expr{fn.pop()}})
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID(name)},
+		Args: []ast.Expr{fn.pop()}}, "float64")
 }
 
 // Executes a binary float64 math call.
@@ -414,103 +414,85 @@ func (fn *funcCompiler) binMath64(name string) {
 	y := fn.pop()
 	x := fn.pop()
 	fn.pushPure(&ast.CallExpr{
-		Fun: &ast.SelectorExpr{
-			X:   newID("math"),
-			Sel: newID(name)},
-		Args: []ast.Expr{x, y}})
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID(name)},
+		Args: []ast.Expr{x, y}}, "float64")
 }
 
 // Executes a unary float32 math call.
 func (fn *funcCompiler) uniMath32(name string) {
-	fn.pushPure(
-		convert(&ast.CallExpr{
-			Fun: &ast.SelectorExpr{
-				X:   newID("math"),
-				Sel: newID(name)},
-			Args: []ast.Expr{convert(fn.pop(), "float64")},
-		}, "float32"))
+	fn.pushPureConvert(&ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID(name)},
+		Args: []ast.Expr{convert(fn.pop(), "float64")}}, "float32")
 }
 
 // Executes a Float32bits call.
 func (fn *funcCompiler) float32bits() {
-	fn.pushPure(
-		convert(&ast.CallExpr{
-			Fun: &ast.SelectorExpr{
-				X:   newID("math"),
-				Sel: newID("Float32bits")},
-			Args: []ast.Expr{fn.pop()},
-		}, "int32"))
+	fn.pushPureConvert(&ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID("Float32bits")},
+		Args: []ast.Expr{fn.pop()}}, "int32")
 }
 
 // Executes a Float64bits call.
 func (fn *funcCompiler) float64bits() {
-	fn.pushPure(
-		convert(&ast.CallExpr{
-			Fun: &ast.SelectorExpr{
-				X:   newID("math"),
-				Sel: newID("Float64bits")},
-			Args: []ast.Expr{fn.pop()},
-		}, "int64"))
+	fn.pushPureConvert(&ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID("Float64bits")},
+		Args: []ast.Expr{fn.pop()}}, "int64")
 }
 
 // Executes a Float32frombits call.
 func (fn *funcCompiler) float32frombits() {
 	fn.pushPure(&ast.CallExpr{
-		Fun: &ast.SelectorExpr{
-			X:   newID("math"),
-			Sel: newID("Float32frombits")},
-		Args: []ast.Expr{convert(fn.pop(), "uint32")}})
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID("Float32frombits")},
+		Args: []ast.Expr{convert(fn.pop(), "uint32")}}, "float32")
 }
 
 // Executes a Float64frombits call.
 func (fn *funcCompiler) float64frombits() {
 	fn.pushPure(&ast.CallExpr{
-		Fun: &ast.SelectorExpr{
-			X:   newID("math"),
-			Sel: newID("Float64frombits")},
-		Args: []ast.Expr{convert(fn.pop(), "uint64")}})
+		Fun:  &ast.SelectorExpr{X: newID("math"), Sel: newID("Float64frombits")},
+		Args: []ast.Expr{convert(fn.pop(), "uint64")}}, "float64")
 }
 
 // Executes a unary helper call.
 func (fn *funcCompiler) uniHelper(name string) {
 	fn.helpers.add(name)
+	t := fn.topType()
 	fn.pushPureIf(pureHelpers.has(name),
-		&ast.CallExpr{
-			Fun:  newID(name),
-			Args: []ast.Expr{fn.pop()}})
+		&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{fn.pop()}}, t)
 }
 
 // Executes a binary helper call.
 func (fn *funcCompiler) binHelper(name string) {
 	fn.helpers.add(name)
+	t := fn.topType()
 	y := fn.pop()
 	x := fn.pop()
 	fn.pushPureIf(pureHelpers.has(name),
-		&ast.CallExpr{
-			Fun:  newID(name),
-			Args: []ast.Expr{x, y}})
+		&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x, y}}, t)
 }
 
 // Executes a signed division helper.
 func (fn *funcCompiler) divHelper(typ string) {
+	t := fn.topType()
 	y := fn.pop()
 	x := fn.pop()
 	if v, ok := islit(y, typ); !ok {
 		name := typ + "_div_s"
 		fn.helpers.add(name)
-		fn.push(&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x, y}})
+		fn.push(&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x, y}}, t)
 	} else if v == -1 {
 		name := typ + "_neg_s"
 		fn.helpers.add(name)
-		fn.push(&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x}})
+		fn.push(&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x}}, t)
 	} else {
-		fn.pushPureIf(v != 0, &ast.BinaryExpr{Op: token.QUO, X: x, Y: y})
+		fn.pushPureIf(v != 0, &ast.BinaryExpr{Op: token.QUO, X: x, Y: y}, t)
 	}
 }
 
 // Executes a bitwise shift helper.
 func (fn *funcCompiler) bitHelper(name string) {
 	typ, op, _ := strings.Cut(name, "_")
+	t := fn.topType()
 	y := fn.pop()
 	x := fn.pop()
 
@@ -518,9 +500,7 @@ func (fn *funcCompiler) bitHelper(name string) {
 	if !ok {
 		fn.helpers.add(name)
 		fn.pushPureIf(pureHelpers.has(name),
-			&ast.CallExpr{
-				Fun:  newID(name),
-				Args: []ast.Expr{x, y}})
+			&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x, y}}, t)
 		return
 	}
 
@@ -528,12 +508,11 @@ func (fn *funcCompiler) bitHelper(name string) {
 		v &= 31
 	}
 	y = &ast.BasicLit{Kind: token.INT, Value: strconv.FormatInt(v&63, 10)}
-	var expr ast.Expr
 	switch op {
 	case "shl":
-		expr = &ast.BinaryExpr{Op: token.SHL, X: x, Y: y}
+		fn.pushPure(&ast.BinaryExpr{Op: token.SHL, X: x, Y: y}, t)
 	case "shr_s":
-		expr = &ast.BinaryExpr{Op: token.SHR, X: x, Y: y}
+		fn.pushPure(&ast.BinaryExpr{Op: token.SHR, X: x, Y: y}, t)
 	case "shr_u":
 		s := "int32"
 		u := "uint32"
@@ -541,19 +520,17 @@ func (fn *funcCompiler) bitHelper(name string) {
 			s = "int64"
 			u = "uint64"
 		}
-		expr = convert(&ast.BinaryExpr{Op: token.SHR, X: convert(x, u), Y: y}, s)
+		fn.pushPureConvert(&ast.BinaryExpr{Op: token.SHR, X: convert(x, u), Y: y}, s)
 	}
-	fn.pushPure(expr)
 }
 
 // Executes a binary builtin call.
 func (fn *funcCompiler) binBuiltin(name string) {
+	t := fn.topType()
 	y := fn.pop()
 	x := fn.pop()
 	fn.pushPureIf(name == "min" || name == "max",
-		&ast.CallExpr{
-			Fun:  newID(name),
-			Args: []ast.Expr{x, y}})
+		&ast.CallExpr{Fun: newID(name), Args: []ast.Expr{x, y}}, t)
 }
 
 // Executes a zero equality comparison operator.

--- a/translate.go
+++ b/translate.go
@@ -881,7 +881,7 @@ func (t *translator) readConstExpr() (ast.Expr, error) {
 			}
 			stack.append(expr)
 		case 0x23: // global.get
-			expr, _, err := t.globalGet()
+			expr, _, _, err := t.globalGet()
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
No functional change. This will allow codegen to have the prospective go
type available when emitting assignments and definitions.

> Children: [#40](https://redirect.github.com/ncruces/wasm2go/pull/40)