### PR TITLE
Collapse switches

### DIFF
--- a/fncompiler.go
+++ b/fncompiler.go
@@ -610,27 +610,28 @@ func (fn *funcCompiler) newLabel() *ast.Ident {
 }
 
 func (fn *funcCompiler) cleanup() {
+	// Resolve imports.
 	ast.Inspect(fn.decl, fn.resolveImports)
+
+	// Sanity checks.
 	passes.CheckMaterialized(fn.decl)
 
 	if !*noopt {
-		// These two are strictly ordered.
 		passes.RemoveSelfAssigns(fn.decl)
 		passes.RemoveBlankAssigns(fn.decl)
-
+		passes.RemoveUnusedLocals(fn.decl)
 		passes.InlineSwitchGotos(fn.decl)
 		passes.UnnestBlocks(fn.decl)
 		passes.UnnestCases(fn.decl)
 		passes.RemoveEmptyStmts(fn.decl)
 		passes.InlineGotoEnd(fn.decl)
 		passes.InlineGotoReturn(fn.decl)
-
 		if passes.RemoveReceiver(fn.decl) {
 			fn.call.(*ast.ParenExpr).X = fn.decl.Name
 		}
 	}
 
-	// This is needed for correctness.
+	// Go requires this.
 	passes.RemoveUnusedLocals(fn.decl)
 }
 

--- a/fncompiler.go
+++ b/fncompiler.go
@@ -623,6 +623,7 @@ func (fn *funcCompiler) cleanup() {
 	passes.RemoveUnusedLocals(fn.decl)
 	passes.InlineSwitchGotos(fn.decl)
 	passes.UnnestBlocks(fn.decl)
+	passes.UnnestCases(fn.decl)
 	passes.RemoveEmptyStmts(fn.decl)
 	passes.InlineGotoEnd(fn.decl)
 	passes.InlineGotoReturn(fn.decl)

--- a/fncompiler.go
+++ b/fncompiler.go
@@ -613,24 +613,25 @@ func (fn *funcCompiler) cleanup() {
 	ast.Inspect(fn.decl, fn.resolveImports)
 	passes.CheckMaterialized(fn.decl)
 
-	if *noopt {
-		passes.RemoveUnusedLocals(fn.decl)
-		return
+	if !*noopt {
+		// These two are strictly ordered.
+		passes.RemoveSelfAssigns(fn.decl)
+		passes.RemoveBlankAssigns(fn.decl)
+
+		passes.InlineSwitchGotos(fn.decl)
+		passes.UnnestBlocks(fn.decl)
+		passes.UnnestCases(fn.decl)
+		passes.RemoveEmptyStmts(fn.decl)
+		passes.InlineGotoEnd(fn.decl)
+		passes.InlineGotoReturn(fn.decl)
+
+		if passes.RemoveReceiver(fn.decl) {
+			fn.call.(*ast.ParenExpr).X = fn.decl.Name
+		}
 	}
 
-	passes.RemoveSelfAssigns(fn.decl)
-	passes.RemoveBlankAssigns(fn.decl)
+	// This is needed for correctness.
 	passes.RemoveUnusedLocals(fn.decl)
-	passes.InlineSwitchGotos(fn.decl)
-	passes.UnnestBlocks(fn.decl)
-	passes.UnnestCases(fn.decl)
-	passes.RemoveEmptyStmts(fn.decl)
-	passes.InlineGotoEnd(fn.decl)
-	passes.InlineGotoReturn(fn.decl)
-
-	if passes.RemoveReceiver(fn.decl) {
-		fn.call.(*ast.ParenExpr).X = fn.decl.Name
-	}
 }
 
 type funcBlock struct {

--- a/fncompiler.go
+++ b/fncompiler.go
@@ -621,6 +621,7 @@ func (fn *funcCompiler) cleanup() {
 	passes.RemoveSelfAssigns(fn.decl)
 	passes.RemoveBlankAssigns(fn.decl)
 	passes.RemoveUnusedLocals(fn.decl)
+	passes.InlineSwitchGotos(fn.decl)
 	passes.UnnestBlocks(fn.decl)
 	passes.RemoveEmptyStmts(fn.decl)
 	passes.InlineGotoEnd(fn.decl)

--- a/internal/passes/opt.go
+++ b/internal/passes/opt.go
@@ -49,6 +49,9 @@ func RemoveUnusedLocals(fn *ast.FuncDecl) {
 
 // RemoveSelfAssigns removes self assignments to variables.
 func RemoveSelfAssigns(fn *ast.FuncDecl) {
+	uses := countUses(fn)
+	writes := countWrites(fn)
+
 	astutil.Apply(fn, func(c *astutil.Cursor) bool {
 		if n, ok := c.Node().(*ast.AssignStmt); ok && n.Tok == token.ASSIGN {
 			// Skip multi-value assignments of a call.
@@ -61,7 +64,14 @@ func RemoveSelfAssigns(fn *ast.FuncDecl) {
 				// Skip self assignments.
 				if idL, ok := n.Lhs[i].(*ast.Ident); ok {
 					if idR, ok := expr.(*ast.Ident); ok && idL.Name == idR.Name {
-						continue
+						u := uses[idL.Name] - 2
+						w := writes[idL.Name] - 1
+						// Don't remove the last read.
+						if u > w {
+							uses[idL.Name] = u
+							writes[idL.Name] = w
+							continue
+						}
 					}
 				}
 				lhs = append(lhs, n.Lhs[i])
@@ -214,9 +224,18 @@ func UnnestBlocks(fn *ast.FuncDecl) {
 // UnnestCases removes block statements that are the only statement in a case clause.
 func UnnestCases(fn *ast.FuncDecl) {
 	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
-		if cc, ok := c.Node().(*ast.CaseClause); ok && len(cc.Body) == 1 {
-			if b, ok := cc.Body[0].(*ast.BlockStmt); ok {
-				cc.Body = b.List
+		switch cc := c.Node().(type) {
+		case *ast.CaseClause:
+			if len(cc.Body) == 1 {
+				if b, ok := cc.Body[0].(*ast.BlockStmt); ok {
+					cc.Body = b.List
+				}
+			}
+		case *ast.CommClause:
+			if len(cc.Body) == 1 {
+				if b, ok := cc.Body[0].(*ast.BlockStmt); ok {
+					cc.Body = b.List
+				}
 			}
 		}
 		return true

--- a/internal/passes/opt.go
+++ b/internal/passes/opt.go
@@ -13,7 +13,7 @@ func RemoveUnusedLocals(fn *ast.FuncDecl) {
 	blank := ast.NewIdent("_")
 
 	// If an identifer only shows up once,
-	// in the left side of an definition,
+	// in the left side of a definition,
 	// replace it with the blank identifier.
 	// If no names are being defined,
 	// turn the definition into an assignment.
@@ -254,7 +254,7 @@ func InlineGotoEnd(fn *ast.FuncDecl) {
 	fn.Body.List = fn.Body.List[:last]
 
 	// Fix the branches.
-	astutil.Apply(fn.Body, nil, func(c *astutil.Cursor) bool {
+	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		if branch, ok := c.Node().(*ast.BranchStmt); ok &&
 			branch.Tok == token.GOTO && branch.Label.Name == ls.Label.Name {
 			c.Replace(&ast.ReturnStmt{})
@@ -265,14 +265,10 @@ func InlineGotoEnd(fn *ast.FuncDecl) {
 
 // InlineGotoReturn replaces a goto to a label with a naked return with a direct return.
 func InlineGotoReturn(fn *ast.FuncDecl) {
-	if fn.Body == nil {
-		return
-	}
-
 	found := set[string]{}
 
 	// Find all labels that point directly to a naked return and remove the label.
-	astutil.Apply(fn.Body, nil, func(c *astutil.Cursor) bool {
+	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		if ls, ok := c.Node().(*ast.LabeledStmt); ok {
 			if ret, ok := ls.Stmt.(*ast.ReturnStmt); ok && len(ret.Results) == 0 {
 				found.add(ls.Label.Name)
@@ -288,7 +284,7 @@ func InlineGotoReturn(fn *ast.FuncDecl) {
 
 	// Replace gotos to those labels with a naked return.
 	ret := &ast.ReturnStmt{}
-	astutil.Apply(fn.Body, nil, func(c *astutil.Cursor) bool {
+	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
 		if branch, ok := c.Node().(*ast.BranchStmt); ok && branch.Tok == token.GOTO {
 			if found.has(branch.Label.Name) {
 				c.Replace(ret)

--- a/internal/passes/opt.go
+++ b/internal/passes/opt.go
@@ -211,6 +211,18 @@ func UnnestBlocks(fn *ast.FuncDecl) {
 	})
 }
 
+// UnnestCases removes block statements that are the only statement in a case clause.
+func UnnestCases(fn *ast.FuncDecl) {
+	astutil.Apply(fn, nil, func(c *astutil.Cursor) bool {
+		if cc, ok := c.Node().(*ast.CaseClause); ok && len(cc.Body) == 1 {
+			if b, ok := cc.Body[0].(*ast.BlockStmt); ok {
+				cc.Body = b.List
+			}
+		}
+		return true
+	})
+}
+
 // InlineGotoEnd replaces a goto to the end of a function with return.
 func InlineGotoEnd(fn *ast.FuncDecl) {
 	last := len(fn.Body.List) - 1

--- a/internal/passes/switch.go
+++ b/internal/passes/switch.go
@@ -32,6 +32,9 @@ func InlineSwitchGotos(fn *ast.FuncDecl) {
 				if id < 0 {
 					continue
 				}
+				if !inlinableIntoSwitch(stmts[i+2:], uses) {
+					continue
+				}
 				// Perform the optimization, and try again.
 				inlineSwitchCase(sw, id, fthrough, stmts[i+2:])
 				stmts = stmts[:i+1]
@@ -118,6 +121,42 @@ func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int, fthrough bool) {
 	return idx, fthrough
 }
 
+// Checks if stmts can be safely inlined into a switch.
+func inlinableIntoSwitch(stmts []ast.Stmt, branches map[string]int) bool {
+	if len(stmts) == 0 {
+		return true
+	}
+
+	// Fallthrough at the end of stmts would change meaning.
+	if br, ok := stmts[len(stmts)-1].(*ast.BranchStmt); ok && br.Tok == token.FALLTHROUGH {
+		return false
+	}
+
+	labels := set[string]{}
+	for _, s := range stmts {
+		// Collect labels.
+		for ls, ok := s.(*ast.LabeledStmt); ok; {
+			labels.add(ls.Label.Name)
+			ls, ok = ls.Stmt.(*ast.LabeledStmt)
+		}
+		// Unlabeled break would change meaning.
+		if canBreak(s) {
+			return false
+		}
+	}
+
+	// Labels become invalid if used outside stmts.
+	if len(labels) > 0 {
+		local := countBranches(&ast.BlockStmt{List: stmts})
+		for name := range labels {
+			if branches[name] > local[name] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // Inlines stmts into case clause i of the switch statement.
 func inlineSwitchCase(sw *ast.SwitchStmt, idx int, fthrough bool, stmts []ast.Stmt) {
 	cases := sw.Body.List
@@ -129,13 +168,13 @@ func inlineSwitchCase(sw *ast.SwitchStmt, idx int, fthrough bool, stmts []ast.St
 		cc := cases[len(cases)-1].(*ast.CaseClause)
 		cc.Body = append(cc.Body, &ast.BranchStmt{Tok: token.FALLTHROUGH})
 	}
-	// Move i to the end of the list, inplace.
+	// Move idx to the end of the list, inplace.
 	copy(cases[idx:], cases[idx+1:])
 	cases[len(cases)-1] = cc
 }
 
 // Checks if s can complete normally.
-// It's OK to always return true.
+// It's acceptable to always return true.
 func canComplete(s ast.Stmt) bool {
 	switch s := s.(type) {
 	case *ast.ReturnStmt, *ast.BranchStmt:

--- a/internal/passes/switch.go
+++ b/internal/passes/switch.go
@@ -69,7 +69,7 @@ func findSwitchStmt(s ast.Stmt) *ast.SwitchStmt {
 // returns -1 if inlining it would be invalid.
 func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int) {
 	// If such a case clause is found,
-	// it will be moved to the end of the switch statement,
+	// it should move to the end of the switch statement,
 	// and the label will be "inlined" into the case clause.
 	//
 	// To move the clause to the end of the switch statement,
@@ -98,20 +98,25 @@ func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int) {
 		}
 		switch c := cc.Body[len(cc.Body)-1].(type) {
 		case *ast.ReturnStmt:
-			// This clause terminates.
 			hadFallthrough = false
 		case *ast.BranchStmt:
-			// This clause terminates, but is it just goto label and can it be moved?
-			if len(cc.Body) == 1 && c.Tok == token.GOTO && c.Label.Name == label && !hadFallthrough {
+			// Is the body just `goto label`?
+			// Does it need to move, and can it be moved?
+			if (c.Tok == token.GOTO && c.Label.Name == label && len(cc.Body) == 1) &&
+				(i == len(sw.Body.List)-1 || !hadFallthrough) {
 				idx = i
 			}
 			hadFallthrough = c.Tok == token.FALLTHROUGH
 		default:
-			// This clause might not terminate, but is it the final one?
+			if !canComplete(c) {
+				hadFallthrough = false
+				break
+			}
+			// Check that this is the final clause.
 			if i != len(sw.Body.List)-1 {
 				return -1
 			}
-			// If it is the final one, we need to add a fallthrough.
+			// If so, we need to add a fallthrough.
 			if hasDefault && idx >= 0 {
 				cc.Body = append(cc.Body, &ast.BranchStmt{Tok: token.FALLTHROUGH})
 				return idx
@@ -133,4 +138,32 @@ func inlineSwitchCase(sw *ast.SwitchStmt, i int, stmts []ast.Stmt) {
 	// Move i to the end of the list, inplace.
 	copy(cases[i:], cases[i+1:])
 	cases[len(cases)-1] = cc
+}
+
+// Checks if s can possibly complete normally.
+// It's OK to always return true.
+func canComplete(s ast.Stmt) bool {
+	switch s := s.(type) {
+	case *ast.ReturnStmt, *ast.BranchStmt:
+		return false
+	case *ast.LabeledStmt:
+		return canComplete(s.Stmt)
+	case *ast.BlockStmt:
+		return len(s.List) == 0 || canComplete(s.List[len(s.List)-1])
+	case *ast.IfStmt:
+		return s.Else == nil || canComplete(s.Body) || canComplete(s.Else)
+	case *ast.SwitchStmt:
+		var hasDefault bool
+		for _, c := range s.Body.List {
+			cc := c.(*ast.CaseClause)
+			if len(cc.Body) == 0 || hasBreak(cc) || canComplete(cc.Body[len(cc.Body)-1]) {
+				return true
+			}
+			if cc.List == nil {
+				hasDefault = true
+			}
+		}
+		return !hasDefault
+	}
+	return true
 }

--- a/internal/passes/switch.go
+++ b/internal/passes/switch.go
@@ -1,0 +1,136 @@
+package passes
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// InlineSwitchGotos inlines switch cases that consist of a single goto,
+// to an otherwise unused label.
+func InlineSwitchGotos(fn *ast.FuncDecl) {
+	if fn.Body == nil {
+		return
+	}
+
+	uses := map[string]int{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if br, ok := n.(*ast.BranchStmt); ok {
+			uses[br.Label.Name]++
+		}
+		return true
+	})
+
+	// This loop applies the optimization iteratively,
+	// re-verifying conditions after every modification.
+	for modified := true; modified; {
+		modified = false
+		postApplyStmts(fn.Body, func(stmts []ast.Stmt) []ast.Stmt {
+			for i := 0; i+1 < len(stmts) && !modified; i++ {
+				// A labeled statement, followed by an empty statement,
+				// only used once as a goto target.
+				ls, ok := stmts[i+1].(*ast.LabeledStmt)
+				if !ok || !is[*ast.EmptyStmt](ls.Stmt) || uses[ls.Label.Name] != 1 {
+					continue
+				}
+				// Find the preceeding switch statement.
+				sw := findSwitchStmt(stmts[i])
+				if sw == nil {
+					continue
+				}
+				// Find the case label, and validate the optimization.
+				id := findSwitchCase(sw, ls.Label.Name)
+				if id < 0 {
+					continue
+				}
+				// Perform the optimization, and try again.
+				inlineSwitchCase(sw, id, stmts[i+2:])
+				stmts = stmts[:i+1]
+				modified = true
+			}
+			return stmts
+		})
+	}
+}
+
+// Finds the switch statement at the end of s.
+func findSwitchStmt(s ast.Stmt) *ast.SwitchStmt {
+	switch s := s.(type) {
+	case *ast.SwitchStmt:
+		return s
+	case *ast.BlockStmt:
+		if len := len(s.List); len > 0 {
+			return findSwitchStmt(s.List[len-1])
+		}
+	}
+	return nil
+}
+
+// Finds the index of a case clause whose body is goto label;
+// returns -1 if inlining it would be invalid.
+func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int) {
+	// If such a case clause is found,
+	// it will be moved to the end of the switch statement,
+	// and the label will be "inlined" into the case clause.
+	//
+	// To move the clause to the end of the switch statement,
+	// the preceeding clause cannot end in a fallthrough statement.
+	//
+	// To move the label into the switch,
+	// execution cannot naturally flow out of the switch statement
+	// except through the current final clause,
+	// in which case we will need to add a fallthrough to that clause.
+	//
+	// To ensure execution cannot flow out of the switch statement,
+	// a default clause must exist, and all clauses (except the final one)
+	// must return/goto/continue/falthrough and never break.
+	idx = -1
+	var hasDefault bool
+	var hadFallthrough bool
+	for i, c := range sw.Body.List {
+		cc := c.(*ast.CaseClause)
+		// Remember if the switch has a default case.
+		if cc.List == nil {
+			hasDefault = true
+		}
+		// Check that the case is neither empty nor breaks.
+		if len(cc.Body) == 0 || hasBreak(cc) {
+			return -1
+		}
+		switch c := cc.Body[len(cc.Body)-1].(type) {
+		case *ast.ReturnStmt:
+			// This clause terminates.
+			hadFallthrough = false
+		case *ast.BranchStmt:
+			// This clause terminates, but is it just goto label and can it be moved?
+			if len(cc.Body) == 1 && c.Tok == token.GOTO && c.Label.Name == label && !hadFallthrough {
+				idx = i
+			}
+			hadFallthrough = c.Tok == token.FALLTHROUGH
+		default:
+			// This clause might not terminate, but is it the final one?
+			if i != len(sw.Body.List)-1 {
+				return -1
+			}
+			// If it is the final one, we need to add a fallthrough.
+			if hasDefault && idx >= 0 {
+				cc.Body = append(cc.Body, &ast.BranchStmt{Tok: token.FALLTHROUGH})
+				return idx
+			}
+		}
+	}
+	if !hasDefault {
+		return -1
+	}
+	return idx
+}
+
+// Inlines stmts into case clause i of the switch statement.
+func inlineSwitchCase(sw *ast.SwitchStmt, i int, stmts []ast.Stmt) {
+	cases := sw.Body.List
+	// Replace the body with stmts.
+	cc := cases[i].(*ast.CaseClause)
+	cc.Body = append(cc.Body[:0], stmts...)
+	// Move i to the end of the list, inplace.
+	copy(cases[i:], cases[i+1:])
+	cases[len(cases)-1] = cc
+}

--- a/internal/passes/switch.go
+++ b/internal/passes/switch.go
@@ -8,12 +8,8 @@ import (
 // InlineSwitchGotos inlines switch cases that consist of a single goto,
 // to an otherwise unused label.
 func InlineSwitchGotos(fn *ast.FuncDecl) {
-	if fn.Body == nil {
-		return
-	}
-
 	uses := map[string]int{}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
+	ast.Inspect(fn, func(n ast.Node) bool {
 		if br, ok := n.(*ast.BranchStmt); ok {
 			uses[br.Label.Name]++
 		}
@@ -24,8 +20,8 @@ func InlineSwitchGotos(fn *ast.FuncDecl) {
 	// re-verifying conditions after every modification.
 	for modified := true; modified; {
 		modified = false
-		postApplyStmts(fn.Body, func(stmts []ast.Stmt) []ast.Stmt {
-			for i := 0; i+1 < len(stmts) && !modified; i++ {
+		postApplyStmts(fn, func(stmts []ast.Stmt) []ast.Stmt {
+			for i := 0; i+1 < len(stmts); i++ {
 				// A labeled statement, followed by an empty statement,
 				// only used once as a goto target.
 				ls, ok := stmts[i+1].(*ast.LabeledStmt)
@@ -46,6 +42,7 @@ func InlineSwitchGotos(fn *ast.FuncDecl) {
 				inlineSwitchCase(sw, id, stmts[i+2:])
 				stmts = stmts[:i+1]
 				modified = true
+				break
 			}
 			return stmts
 		})

--- a/internal/passes/switch.go
+++ b/internal/passes/switch.go
@@ -8,13 +8,7 @@ import (
 // InlineSwitchGotos inlines switch cases that consist of a single goto,
 // to an otherwise unused label.
 func InlineSwitchGotos(fn *ast.FuncDecl) {
-	uses := map[string]int{}
-	ast.Inspect(fn, func(n ast.Node) bool {
-		if br, ok := n.(*ast.BranchStmt); ok {
-			uses[br.Label.Name]++
-		}
-		return true
-	})
+	uses := countBranches(fn)
 
 	// This loop applies the optimization iteratively,
 	// re-verifying conditions after every modification.
@@ -34,15 +28,14 @@ func InlineSwitchGotos(fn *ast.FuncDecl) {
 					continue
 				}
 				// Find the case label, and validate the optimization.
-				id := findSwitchCase(sw, ls.Label.Name)
+				id, fthrough := findSwitchCase(sw, ls.Label.Name)
 				if id < 0 {
 					continue
 				}
 				// Perform the optimization, and try again.
-				inlineSwitchCase(sw, id, stmts[i+2:])
+				inlineSwitchCase(sw, id, fthrough, stmts[i+2:])
 				stmts = stmts[:i+1]
 				modified = true
-				break
 			}
 			return stmts
 		})
@@ -64,7 +57,7 @@ func findSwitchStmt(s ast.Stmt) *ast.SwitchStmt {
 
 // Finds the index of a case clause whose body is goto label;
 // returns -1 if inlining it would be invalid.
-func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int) {
+func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int, fthrough bool) {
 	// If such a case clause is found,
 	// it should move to the end of the switch statement,
 	// and the label will be "inlined" into the case clause.
@@ -90,8 +83,8 @@ func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int) {
 			hasDefault = true
 		}
 		// Check that the case is neither empty nor breaks.
-		if len(cc.Body) == 0 || hasBreak(cc) {
-			return -1
+		if len(cc.Body) == 0 || canBreak(cc) {
+			return -1, false
 		}
 		switch c := cc.Body[len(cc.Body)-1].(type) {
 		case *ast.ReturnStmt:
@@ -111,33 +104,37 @@ func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int) {
 			}
 			// Check that this is the final clause.
 			if i != len(sw.Body.List)-1 {
-				return -1
+				return -1, false
 			}
 			// If so, we need to add a fallthrough.
 			if hasDefault && idx >= 0 {
-				cc.Body = append(cc.Body, &ast.BranchStmt{Tok: token.FALLTHROUGH})
-				return idx
+				fthrough = true
 			}
 		}
 	}
 	if !hasDefault {
-		return -1
+		return -1, false
 	}
-	return idx
+	return idx, fthrough
 }
 
 // Inlines stmts into case clause i of the switch statement.
-func inlineSwitchCase(sw *ast.SwitchStmt, i int, stmts []ast.Stmt) {
+func inlineSwitchCase(sw *ast.SwitchStmt, idx int, fthrough bool, stmts []ast.Stmt) {
 	cases := sw.Body.List
 	// Replace the body with stmts.
-	cc := cases[i].(*ast.CaseClause)
+	cc := cases[idx].(*ast.CaseClause)
 	cc.Body = append(cc.Body[:0], stmts...)
+	// Add fallthrough if needed.
+	if fthrough {
+		cc := cases[len(cases)-1].(*ast.CaseClause)
+		cc.Body = append(cc.Body, &ast.BranchStmt{Tok: token.FALLTHROUGH})
+	}
 	// Move i to the end of the list, inplace.
-	copy(cases[i:], cases[i+1:])
+	copy(cases[idx:], cases[idx+1:])
 	cases[len(cases)-1] = cc
 }
 
-// Checks if s can possibly complete normally.
+// Checks if s can complete normally.
 // It's OK to always return true.
 func canComplete(s ast.Stmt) bool {
 	switch s := s.(type) {
@@ -153,7 +150,7 @@ func canComplete(s ast.Stmt) bool {
 		var hasDefault bool
 		for _, c := range s.Body.List {
 			cc := c.(*ast.CaseClause)
-			if len(cc.Body) == 0 || hasBreak(cc) || canComplete(cc.Body[len(cc.Body)-1]) {
+			if len(cc.Body) == 0 || canBreak(cc) || canComplete(cc.Body[len(cc.Body)-1]) {
 				return true
 			}
 			if cc.List == nil {

--- a/internal/passes/switch.go
+++ b/internal/passes/switch.go
@@ -10,8 +10,7 @@ import (
 func InlineSwitchGotos(fn *ast.FuncDecl) {
 	uses := countBranches(fn)
 
-	// This loop applies the optimization iteratively,
-	// re-verifying conditions after every modification.
+	// This loop retries the optimization iteratively.
 	for modified := true; modified; {
 		modified = false
 		postApplyStmts(fn, func(stmts []ast.Stmt) []ast.Stmt {
@@ -62,7 +61,7 @@ func findSwitchStmt(s ast.Stmt) *ast.SwitchStmt {
 // returns -1 if inlining it would be invalid.
 func findSwitchCase(sw *ast.SwitchStmt, label string) (idx int, fthrough bool) {
 	// If such a case clause is found,
-	// it should move to the end of the switch statement,
+	// it must move to the end of the switch statement,
 	// and the label will be "inlined" into the case clause.
 	//
 	// To move the clause to the end of the switch statement,
@@ -157,7 +156,7 @@ func inlinableIntoSwitch(stmts []ast.Stmt, branches map[string]int) bool {
 	return true
 }
 
-// Inlines stmts into case clause i of the switch statement.
+// Inlines stmts into case clause idx of the switch statement.
 func inlineSwitchCase(sw *ast.SwitchStmt, idx int, fthrough bool, stmts []ast.Stmt) {
 	cases := sw.Body.List
 	// Replace the body with stmts.

--- a/internal/passes/switch_test.go
+++ b/internal/passes/switch_test.go
@@ -1,0 +1,489 @@
+package passes
+
+import (
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func TestInlineSwitchGotos(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "inline last case",
+			src: `func f(x int) {
+				switch x {
+				default:
+					return
+				case 0:
+					return
+				case 1:
+					goto lbl
+				}
+			lbl:
+				;
+				x++
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				default:
+					return
+				case 0:
+					return
+				case 1:
+					x++
+					return
+				}
+			}`,
+		},
+		{
+			name: "nested switch",
+			src: `func f(x int) {
+				{
+					switch x {
+					default:
+						return
+					case 0:
+						return
+					case 1:
+						goto lbl
+					}
+				}
+			lbl:
+				;
+				x++
+				return
+			}`,
+			want: `func f(x int) {
+				{
+					switch x {
+					default:
+						return
+					case 0:
+						return
+					case 1:
+						x++
+						return
+					}
+				}
+			}`,
+		},
+		{
+			name: "inline first case",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				case 1:
+					return
+				default:
+					return
+				}
+			lbl:
+				;
+				x++
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 1:
+					return
+				default:
+					return
+				case 0:
+					x++
+					return
+				}
+			}`,
+		},
+		{
+			name: "inline middle case",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					return
+				case 1:
+					goto lbl
+				default:
+					return
+				}
+			lbl:
+				;
+				x++
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 0:
+					return
+				default:
+					return
+				case 1:
+					x++
+					return
+				}
+			}`,
+		},
+		{
+			name: "no-op: label used more than once",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					goto lbl
+				}
+			lbl:
+				;
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					goto lbl
+				}
+			lbl:
+				;
+				return
+			}`,
+		},
+		{
+			name: "no-op: no default clause",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				case 1:
+					return
+				}
+			lbl:
+				;
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				case 1:
+					return
+				}
+			lbl:
+				;
+				return
+			}`,
+		},
+		{
+			name: "no-op: preceding case has fallthrough",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					fallthrough
+				case 1:
+					goto lbl
+				default:
+					return
+				}
+			lbl:
+				;
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 0:
+					fallthrough
+				case 1:
+					goto lbl
+				default:
+					return
+				}
+			lbl:
+				;
+				return
+			}`,
+		},
+		{
+			name: "no-op: stmts contain break",
+			src: `func f(x int) {
+				switch {
+				default:
+					switch x {
+					case 0:
+						goto lbl
+					default:
+						return
+					}
+				lbl:
+					;
+					break
+				}
+			}`,
+			want: `func f(x int) {
+				switch {
+				default:
+					switch x {
+					case 0:
+						goto lbl
+					default:
+						return
+					}
+				lbl:
+					;
+					break
+				}
+			}`,
+		},
+		{
+			name: "no-op: stmts end with fallthrough",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					switch x {
+					case 0:
+						goto lbl
+					default:
+						return
+					}
+				lbl:
+					;
+					fallthrough
+				default:
+				}
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 0:
+					switch x {
+					case 0:
+						goto lbl
+					default:
+						return
+					}
+				lbl:
+					;
+					fallthrough
+				default:
+				}
+			}`,
+		},
+		{
+			name: "no-op: inlined label has external goto",
+			src: `func f(x int) {
+				goto exit
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					return
+				}
+			lbl:
+				;
+			exit:
+				return
+			}`,
+			want: `func f(x int) {
+				goto exit
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					return
+				}
+			lbl:
+				;
+			exit:
+				return
+			}`,
+		},
+		{
+			name: "no-op: switch can't complete",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					break
+				case 1:
+					x++
+				}
+			lbl:
+				;
+				x--
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					break
+				case 1:
+					x++
+				}
+			lbl:
+				;
+				x--
+				return
+			}`,
+		},
+		{
+			name: "last case can complete: fallthrough added",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					return
+				case 1:
+					x++
+				}
+			lbl:
+				;
+				x--
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				default:
+					return
+				case 1:
+					x++
+					fallthrough
+				case 0:
+					x--
+					return
+				}
+			}`,
+		},
+		{
+			name: "empty inlined stmts",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					return
+				}
+			lbl:
+			}`,
+			want: `func f(x int) {
+				switch x {
+				default:
+					return
+				case 0:
+				}
+			}`,
+		},
+		{
+			name: "nested return",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl
+				default:
+					{
+						return
+					}
+				}
+			lbl:
+			}`,
+			want: `func f(x int) {
+				switch x {
+				default:
+					{
+						return
+					}
+				case 0:
+				}
+			}`,
+		},
+		{
+			name: "iterative: two patterns collapsed",
+			src: `func f(x int) {
+				switch x {
+				case 0:
+					goto lbl1
+				default:
+					return
+				}
+			lbl1:
+				;
+				switch x {
+				case 1:
+					goto lbl2
+				default:
+					return
+				}
+			lbl2:
+				;
+				return
+			}`,
+			want: `func f(x int) {
+				switch x {
+				default:
+					return
+				case 0:
+					switch x {
+					default:
+						return
+					case 1:
+						return
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := parseFunc(t, tt.src)
+			InlineSwitchGotos(fn)
+			got := formatFunc(t, fn)
+			want := normalizeFunc(t, tt.want)
+			if got != want {
+				t.Errorf("got:\n%s\n\nwant:\n%s", got, want)
+			}
+		})
+	}
+}
+
+func parseFunc(t *testing.T, src string) *ast.FuncDecl {
+	t.Helper()
+	src = "package p\n" + src
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return f.Decls[0].(*ast.FuncDecl)
+}
+
+func formatFunc(t *testing.T, fn *ast.FuncDecl) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file := &ast.File{
+		Name:  ast.NewIdent("p"),
+		Decls: []ast.Decl{fn},
+	}
+	var sb strings.Builder
+	if err := format.Node(&sb, fset, file); err != nil {
+		t.Fatalf("format error: %v", err)
+	}
+	out := sb.String()
+	out = strings.TrimPrefix(out, "package p\n\n")
+	return strings.TrimSpace(out)
+}
+
+func normalizeFunc(t *testing.T, src string) string {
+	t.Helper()
+	fn := parseFunc(t, src)
+	return formatFunc(t, fn)
+}

--- a/internal/passes/util.go
+++ b/internal/passes/util.go
@@ -23,11 +23,11 @@ func postApplyStmts(n ast.Node, fn func([]ast.Stmt) []ast.Stmt) {
 	})
 }
 
-// Counts uses of an identifier.
-func countUses(fn *ast.FuncDecl) map[string]int {
+// Counts uses of each identifier.
+func countUses(n ast.Node) map[string]int {
 	uses := map[string]int{}
 	unknown := set[string]{}
-	ast.Inspect(fn, func(n ast.Node) bool {
+	ast.Inspect(n, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.Ident:
 			uses[n.Name]++
@@ -46,10 +46,10 @@ func countUses(fn *ast.FuncDecl) map[string]int {
 	return uses
 }
 
-// Counts writes to an identifier.
-func countWrites(fn *ast.FuncDecl) map[string]int {
+// Counts writes to each identifier.
+func countWrites(n ast.Node) map[string]int {
 	writes := map[string]int{}
-	ast.Inspect(fn, func(node ast.Node) bool {
+	ast.Inspect(n, func(node ast.Node) bool {
 		switch n := node.(type) {
 		case *ast.ValueSpec:
 			for _, id := range n.Names {
@@ -71,6 +71,18 @@ func countWrites(fn *ast.FuncDecl) map[string]int {
 	return writes
 }
 
+// Counts branches to each label.
+func countBranches(n ast.Node) map[string]int {
+	branches := map[string]int{}
+	ast.Inspect(n, func(n ast.Node) bool {
+		if br, ok := n.(*ast.BranchStmt); ok && br.Label != nil {
+			branches[br.Label.Name]++
+		}
+		return true
+	})
+	return branches
+}
+
 // Replaces or deletes assignements with a simpler version,
 // i.e. removing some or all variables.
 func simplifyAssign(c *astutil.Cursor, n *ast.AssignStmt, lhs, rhs []ast.Expr) {
@@ -86,11 +98,17 @@ func simplifyAssign(c *astutil.Cursor, n *ast.AssignStmt, lhs, rhs []ast.Expr) {
 	}
 }
 
-// Checks if an AST has a break statement anywhere.
-func hasBreak(n ast.Node) (found bool) {
+// Checks if an unlabeled break escapes n.
+func canBreak(n ast.Node) (found bool) {
 	ast.Inspect(n, func(n ast.Node) bool {
-		if br, ok := n.(*ast.BranchStmt); ok && br.Tok == token.BREAK {
-			found = true
+		switch n := n.(type) {
+		case *ast.ForStmt, *ast.RangeStmt, *ast.SelectStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt:
+			return false
+		case *ast.BranchStmt:
+			if n.Tok == token.BREAK && n.Label == nil {
+				found = true
+				return false
+			}
 		}
 		return !found
 	})

--- a/internal/passes/util.go
+++ b/internal/passes/util.go
@@ -2,6 +2,7 @@ package passes
 
 import (
 	"go/ast"
+	"go/token"
 
 	"golang.org/x/tools/go/ast/astutil"
 )
@@ -85,7 +86,18 @@ func simplifyAssign(c *astutil.Cursor, n *ast.AssignStmt, lhs, rhs []ast.Expr) {
 	}
 }
 
-// http://go.dev/issue/65846
+// Checks if an AST has a break statement anywhere.
+func hasBreak(n ast.Node) (found bool) {
+	ast.Inspect(n, func(n ast.Node) bool {
+		if br, ok := n.(*ast.BranchStmt); ok && br.Tok == token.BREAK {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// is builtin: http://go.dev/issue/65846
 func is[T any](n any) bool {
 	_, ok := n.(T)
 	return ok

--- a/libc-gen/main.go
+++ b/libc-gen/main.go
@@ -143,7 +143,7 @@ func main() {
 		keep = append(keep, fd)
 
 		// Search for other internal dependencies inside this one's scope
-		ast.Inspect(fd.Body, func(n ast.Node) bool {
+		ast.Inspect(fd, func(n ast.Node) bool {
 			if call, ok := n.(*ast.CallExpr); ok {
 				if id, ok := call.Fun.(*ast.Ident); ok {
 					if _, exists := available[id.Name]; exists {

--- a/testdata/trig/trig.go
+++ b/testdata/trig/trig.go
@@ -63,16 +63,14 @@ func (m *Module) Xsin(v0 float64) float64 {
 					goto l2
 				} else {
 					switch int32(v4)&i32(3) - i32(1) {
-					case 0:
-						goto l3
 					case 1:
 						goto l4
 					case 2:
 						goto l5
 					default:
 						goto l0
+					case 0:
 					}
-				l3:
 				}
 				return v0
 			l4:


### PR DESCRIPTION
This pass adds several checks that #37 skipped, including https://github.com/ncruces/wasm2go/pull/37#issuecomment-4691853786.

Please @pgaskin, check that this doesn't break anything.

Please @msuozzo, check that this produces the effect you're after (avoid deep nesting of 100s of blocks).

It's a known issue that this introduces warnings for unreachable `fallthrough` statements. This can be improved (at the cost of more complexity) by introducing a more precise termination check here:
https://github.com/ncruces/wasm2go/blob/b615d76b7d03f0b79bc0e971e2a4560e11491943/internal/passes/switch.go#L114-L118

However, this only causes warnings, and whatever we do there should err only on the side of caution: if in doubt, add the `fallthrough`.

I don't think this can be made simpler, and still be correct. I'm also not entirely sure it is correct yet.